### PR TITLE
Add resizable TipTap image extension with runtime controls

### DIFF
--- a/extensions/resizableImage/ResizableImage.js
+++ b/extensions/resizableImage/ResizableImage.js
@@ -1,0 +1,499 @@
+import { Image } from 'https://esm.sh/@tiptap/extension-image';
+
+const DIRECTIONS = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'];
+
+const toNumberOrNull = value => {
+  if (value === '' || value === null || value === undefined) {
+    return null;
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+  return number;
+};
+
+const sanitizeConstraints = (constraints = {}) => {
+  let minWidth = toNumberOrNull(constraints.minWidth);
+  let maxWidth = toNumberOrNull(constraints.maxWidth);
+  let minHeight = toNumberOrNull(constraints.minHeight);
+  let maxHeight = toNumberOrNull(constraints.maxHeight);
+
+  if (minWidth !== null) {
+    minWidth = Math.max(1, Math.round(minWidth));
+  }
+  if (maxWidth !== null) {
+    maxWidth = Math.max(1, Math.round(maxWidth));
+  }
+  if (minHeight !== null) {
+    minHeight = Math.max(1, Math.round(minHeight));
+  }
+  if (maxHeight !== null) {
+    maxHeight = Math.max(1, Math.round(maxHeight));
+  }
+
+  if (minWidth !== null && maxWidth !== null && minWidth > maxWidth) {
+    [minWidth, maxWidth] = [maxWidth, minWidth];
+  }
+
+  if (minHeight !== null && maxHeight !== null && minHeight > maxHeight) {
+    [minHeight, maxHeight] = [maxHeight, minHeight];
+  }
+
+  return {
+    minWidth,
+    maxWidth,
+    minHeight,
+    maxHeight,
+  };
+};
+
+const clampWithBounds = (value, min, max) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  let result = value;
+  if (min !== null && min !== undefined) {
+    result = Math.max(min, result);
+  }
+  if (max !== null && max !== undefined) {
+    result = Math.min(max, result);
+  }
+
+  return Math.max(1, result);
+};
+
+const parseDimension = value => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const ResizableImage = Image.extend({
+  name: 'image',
+
+  addOptions() {
+    const parentOptions = typeof Image.config.addOptions === 'function'
+      ? Image.config.addOptions.call(this)
+      : {};
+
+    return {
+      ...parentOptions,
+      resizeConstraints: {
+        minWidth: null,
+        maxWidth: null,
+        minHeight: null,
+        maxHeight: null,
+      },
+    };
+  },
+
+  addStorage() {
+    return {
+      constraints: sanitizeConstraints(this.options.resizeConstraints || {}),
+    };
+  },
+
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: element => parseDimension(element.getAttribute('width')),
+        renderHTML: attributes => {
+          if (!attributes.width) {
+            return {};
+          }
+          return { width: String(attributes.width) };
+        },
+      },
+      height: {
+        default: null,
+        parseHTML: element => parseDimension(element.getAttribute('height')),
+        renderHTML: attributes => {
+          if (!attributes.height) {
+            return {};
+          }
+          return { height: String(attributes.height) };
+        },
+      },
+    };
+  },
+
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      setImageSize: options => ({ tr, state, dispatch }) => {
+        const { width, height } = options || {};
+        const { constraints } = this.storage;
+        const hasWidth = width !== undefined;
+        const hasHeight = height !== undefined;
+
+        if (!hasWidth && !hasHeight) {
+          return true;
+        }
+
+        let transaction = tr;
+        let changed = false;
+        const from = state.selection.from;
+        const to = state.selection.to;
+
+        state.doc.nodesBetween(from, to, (node, pos) => {
+          if (node.type !== this.type) {
+            return true;
+          }
+
+          const attrs = { ...node.attrs };
+
+          if (hasWidth) {
+            const parsedWidth = width === null ? null : Number(width);
+            if (parsedWidth === null || Number.isFinite(parsedWidth)) {
+              attrs.width = parsedWidth === null
+                ? null
+                : Math.round(clampWithBounds(parsedWidth, constraints.minWidth, constraints.maxWidth));
+            }
+          }
+
+          if (hasHeight) {
+            const parsedHeight = height === null ? null : Number(height);
+            if (parsedHeight === null || Number.isFinite(parsedHeight)) {
+              attrs.height = parsedHeight === null
+                ? null
+                : Math.round(clampWithBounds(parsedHeight, constraints.minHeight, constraints.maxHeight));
+            }
+          }
+
+          transaction = transaction.setNodeMarkup(pos, undefined, attrs);
+          changed = true;
+          return false;
+        });
+
+        if (changed && dispatch) {
+          dispatch(transaction);
+        }
+
+        return changed;
+      },
+      setImageResizeConstraints: constraints => ({ state, dispatch }) => {
+        const existing = this.storage.constraints || {};
+        const updated = { ...existing };
+        const keys = ['minWidth', 'maxWidth', 'minHeight', 'maxHeight'];
+
+        keys.forEach(key => {
+          if (constraints && Object.prototype.hasOwnProperty.call(constraints, key)) {
+            updated[key] = constraints[key];
+          }
+        });
+
+        const previous = this.storage.constraints || {};
+        const sanitized = sanitizeConstraints(updated);
+        const changed = keys.some(key => sanitized[key] !== previous[key]);
+
+        this.storage.constraints = sanitized;
+
+        if (dispatch && changed) {
+          const tr = state.tr.setMeta('resizableImageConstraints', this.storage.constraints);
+          tr.setMeta('addToHistory', false);
+          dispatch(tr);
+        }
+
+        return true;
+      },
+    };
+  },
+
+  addNodeView() {
+    return ({ node, editor, getPos }) => {
+      let currentNode = node;
+      const container = document.createElement('span');
+      container.classList.add('resizable-image');
+      container.style.position = 'relative';
+      container.style.display = 'inline-block';
+
+      const imageEl = document.createElement('img');
+      imageEl.draggable = false;
+
+      const applyOptionAttributes = () => {
+        const attrs = this.options.HTMLAttributes || {};
+        Object.entries(attrs).forEach(([key, value]) => {
+          if (value === false || value === null || value === undefined) {
+            imageEl.removeAttribute(key);
+          } else {
+            imageEl.setAttribute(key, value);
+          }
+        });
+      };
+
+      applyOptionAttributes();
+      container.appendChild(imageEl);
+
+      const getConstraints = () => this.storage.constraints || {};
+
+      const applyNodeAttributes = attrs => {
+        if (attrs.src && imageEl.getAttribute('src') !== attrs.src) {
+          imageEl.setAttribute('src', attrs.src);
+        }
+
+        if (attrs.alt !== undefined) {
+          if (attrs.alt === null) {
+            imageEl.removeAttribute('alt');
+          } else {
+            imageEl.setAttribute('alt', attrs.alt);
+          }
+        }
+
+        if (attrs.title !== undefined) {
+          if (attrs.title === null) {
+            imageEl.removeAttribute('title');
+          } else {
+            imageEl.setAttribute('title', attrs.title);
+          }
+        }
+
+        const widthValue = parseDimension(attrs.width);
+        const heightValue = parseDimension(attrs.height);
+
+        if (widthValue !== null) {
+          imageEl.style.width = `${widthValue}px`;
+          imageEl.setAttribute('width', String(widthValue));
+        } else {
+          imageEl.style.removeProperty('width');
+          imageEl.removeAttribute('width');
+        }
+
+        if (heightValue !== null) {
+          imageEl.style.height = `${heightValue}px`;
+          imageEl.setAttribute('height', String(heightValue));
+        } else {
+          imageEl.style.removeProperty('height');
+          imageEl.removeAttribute('height');
+        }
+
+        const ignoredKeys = new Set(['src', 'alt', 'title', 'width', 'height']);
+        Object.entries(attrs).forEach(([key, value]) => {
+          if (ignoredKeys.has(key)) {
+            return;
+          }
+
+          if (value === null || value === undefined || value === false) {
+            imageEl.removeAttribute(key);
+          } else {
+            imageEl.setAttribute(key, String(value));
+          }
+        });
+      };
+
+      applyNodeAttributes(node.attrs);
+
+      const applySize = (width, height) => {
+        if (width !== undefined) {
+          if (width === null) {
+            imageEl.style.removeProperty('width');
+            imageEl.removeAttribute('width');
+          } else {
+            imageEl.style.width = `${width}px`;
+            imageEl.setAttribute('width', String(Math.round(width)));
+          }
+        }
+
+        if (height !== undefined) {
+          if (height === null) {
+            imageEl.style.removeProperty('height');
+            imageEl.removeAttribute('height');
+          } else {
+            imageEl.style.height = `${height}px`;
+            imageEl.setAttribute('height', String(Math.round(height)));
+          }
+        }
+      };
+
+      const commitSize = (width, height, affectsWidth, affectsHeight) => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (typeof pos !== 'number' || !editor?.view) {
+          return;
+        }
+
+        const current = editor.view.state.doc.nodeAt(pos);
+        if (!current) {
+          return;
+        }
+
+        const attrs = { ...current.attrs };
+        let changed = false;
+
+        if (affectsWidth) {
+          const previous = parseDimension(attrs.width);
+          const nextValue = width === null ? null : Math.round(width);
+          if (nextValue !== previous) {
+            attrs.width = nextValue;
+            changed = true;
+          }
+        }
+
+        if (affectsHeight) {
+          const previous = parseDimension(attrs.height);
+          const nextValue = height === null ? null : Math.round(height);
+          if (nextValue !== previous) {
+            attrs.height = nextValue;
+            changed = true;
+          }
+        }
+
+        if (!changed) {
+          return;
+        }
+
+        const transaction = editor.view.state.tr.setNodeMarkup(pos, undefined, attrs);
+        editor.view.dispatch(transaction);
+      };
+
+      const startResize = (event, direction) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        editor?.view?.focus?.();
+        if (typeof getPos === 'function') {
+          const pos = getPos();
+          if (typeof pos === 'number') {
+            editor?.commands?.setNodeSelection?.(pos);
+          }
+        }
+
+        const rect = imageEl.getBoundingClientRect();
+        const initialWidth = parseDimension(currentNode.attrs.width) ?? rect.width;
+        const initialHeight = parseDimension(currentNode.attrs.height) ?? rect.height;
+        const affectsWidth = direction.includes('e') || direction.includes('w');
+        const affectsHeight = direction.includes('n') || direction.includes('s');
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const constraints = getConstraints();
+
+        let latestWidth = initialWidth;
+        let latestHeight = initialHeight;
+
+        const pointerId = event.pointerId;
+
+        const handlePointerMove = moveEvent => {
+          moveEvent.preventDefault();
+
+          const deltaX = moveEvent.clientX - startX;
+          const deltaY = moveEvent.clientY - startY;
+
+          let nextWidth = initialWidth;
+          let nextHeight = initialHeight;
+
+          if (affectsWidth) {
+            if (direction.includes('e')) {
+              nextWidth = initialWidth + deltaX;
+            } else if (direction.includes('w')) {
+              nextWidth = initialWidth - deltaX;
+            }
+            nextWidth = clampWithBounds(nextWidth, constraints.minWidth, constraints.maxWidth);
+            latestWidth = nextWidth;
+          }
+
+          if (affectsHeight) {
+            if (direction.includes('s')) {
+              nextHeight = initialHeight + deltaY;
+            } else if (direction.includes('n')) {
+              nextHeight = initialHeight - deltaY;
+            }
+            nextHeight = clampWithBounds(nextHeight, constraints.minHeight, constraints.maxHeight);
+            latestHeight = nextHeight;
+          }
+
+          applySize(
+            affectsWidth ? latestWidth : parseDimension(currentNode.attrs.width),
+            affectsHeight ? latestHeight : parseDimension(currentNode.attrs.height),
+          );
+        };
+
+        const handlePointerUp = () => {
+          if (pointerId !== undefined && event.target?.releasePointerCapture) {
+            try {
+              event.target.releasePointerCapture(pointerId);
+            } catch (error) {
+              // ignore release errors
+            }
+          }
+
+          window.removeEventListener('pointermove', handlePointerMove);
+          window.removeEventListener('pointerup', handlePointerUp);
+          window.removeEventListener('pointercancel', handlePointerUp);
+
+          commitSize(
+            affectsWidth ? latestWidth : parseDimension(currentNode.attrs.width),
+            affectsHeight ? latestHeight : parseDimension(currentNode.attrs.height),
+            affectsWidth,
+            affectsHeight,
+          );
+        };
+
+        if (pointerId !== undefined && event.target?.setPointerCapture) {
+          try {
+            event.target.setPointerCapture(pointerId);
+          } catch (error) {
+            // ignore capture errors
+          }
+        }
+
+        window.addEventListener('pointermove', handlePointerMove);
+        window.addEventListener('pointerup', handlePointerUp);
+        window.addEventListener('pointercancel', handlePointerUp);
+      };
+
+      const handleEntries = [];
+
+      DIRECTIONS.forEach(direction => {
+        const handle = document.createElement('div');
+        handle.classList.add('resize-handle', `resize-handle-${direction}`);
+        const listener = event => startResize(event, direction);
+        handle.addEventListener('pointerdown', listener);
+        handleEntries.push({ handle, listener });
+        container.appendChild(handle);
+      });
+
+      return {
+        dom: container,
+        selectNode: () => {
+          container.classList.add('is-selected');
+        },
+        deselectNode: () => {
+          container.classList.remove('is-selected');
+        },
+        update: updatedNode => {
+          if (updatedNode.type !== currentNode.type) {
+            return false;
+          }
+
+          currentNode = updatedNode;
+          applyNodeAttributes(updatedNode.attrs);
+          return true;
+        },
+        ignoreMutation: mutation => mutation.type === 'attributes' && mutation.target === imageEl,
+        destroy: () => {
+          handleEntries.forEach(({ handle, listener }) => {
+            handle.removeEventListener('pointerdown', listener);
+          });
+        },
+      };
+    };
+  },
+
+  onCreate() {
+    if (this.editor?.storage) {
+      this.editor.storage.resizableImage = this.storage;
+    }
+  },
+
+  onDestroy() {
+    if (this.editor?.storage && this.editor.storage.resizableImage === this.storage) {
+      delete this.editor.storage.resizableImage;
+    }
+  },
+});
+
+export default ResizableImage;

--- a/tiptap-image.html
+++ b/tiptap-image.html
@@ -103,7 +103,150 @@
             border-radius: 4px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
         }
-        
+
+        .toolbar-group {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 8px;
+            background: rgba(0, 123, 255, 0.08);
+            border: 1px solid rgba(0, 123, 255, 0.18);
+            border-radius: 6px;
+            font-size: 13px;
+            color: #495057;
+        }
+
+        .toolbar-group label {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 12px;
+            color: #495057;
+        }
+
+        .toolbar-group .toolbar-group-label {
+            font-weight: 600;
+            font-size: 12px;
+        }
+
+        .toolbar-group .toolbar-group-separator {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        .toolbar-group input[type="number"] {
+            width: 76px;
+            padding: 4px 6px;
+            border: 1px solid #ced4da;
+            border-radius: 4px;
+            font-size: 13px;
+            background: white;
+        }
+
+        .toolbar-group input[type="number"]:focus {
+            border-color: #007bff;
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.15);
+        }
+
+        .image-size-group {
+            margin-left: auto;
+            order: 100;
+        }
+
+        .resizable-image {
+            position: relative;
+            display: inline-block;
+            max-width: 100%;
+        }
+
+        .resizable-image img {
+            display: block;
+            max-width: 100%;
+            height: auto;
+        }
+
+        .resizable-image.is-selected img {
+            outline: 2px solid rgba(0, 123, 255, 0.45);
+            outline-offset: 2px;
+        }
+
+        .resize-handle {
+            position: absolute;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background: rgba(0, 123, 255, 0.95);
+            border: 2px solid white;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            touch-action: none;
+            z-index: 5;
+        }
+
+        .resizable-image.is-selected .resize-handle {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .resize-handle-n {
+            top: 0;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            cursor: ns-resize;
+        }
+
+        .resize-handle-s {
+            bottom: 0;
+            left: 50%;
+            transform: translate(-50%, 50%);
+            cursor: ns-resize;
+        }
+
+        .resize-handle-e {
+            top: 50%;
+            right: 0;
+            transform: translate(50%, -50%);
+            cursor: ew-resize;
+        }
+
+        .resize-handle-w {
+            top: 50%;
+            left: 0;
+            transform: translate(-50%, -50%);
+            cursor: ew-resize;
+        }
+
+        .resize-handle-ne {
+            top: 0;
+            right: 0;
+            transform: translate(50%, -50%);
+            cursor: nesw-resize;
+        }
+
+        .resize-handle-nw {
+            top: 0;
+            left: 0;
+            transform: translate(-50%, -50%);
+            cursor: nwse-resize;
+        }
+
+        .resize-handle-se {
+            bottom: 0;
+            right: 0;
+            transform: translate(50%, 50%);
+            cursor: nwse-resize;
+        }
+
+        .resize-handle-sw {
+            bottom: 0;
+            left: 0;
+            transform: translate(-50%, 50%);
+            cursor: nesw-resize;
+        }
+
         .loading {
             text-align: center;
             padding: 60px 20px;
@@ -125,10 +268,12 @@
         import { TableHeader } from 'https://esm.sh/@tiptap/extension-table-header'
         import { TableCell } from 'https://esm.sh/@tiptap/extension-table-cell'
         import { Placeholder } from 'https://esm.sh/@tiptap/extension-placeholder'
-        import { Image } from 'https://esm.sh/@tiptap/extension-image'
+        import { ResizableImage } from 'https://brahmoon.github.io/wiki/extensions/resizableImage/ResizableImage.js'
         import { DriveImageExtension } from 'https://brahmoon.github.io/wiki/extensions/driveImage/DriveImageExtension.js'
-        
+
         let editor = null;
+        let minWidthInput = null;
+        let maxWidthInput = null;
         
         function createToolbarButton(config) {
             const button = document.createElement('button');
@@ -208,6 +353,18 @@
             
             // テーブル関連ボタンの表示/非表示
             updateTableButtons();
+
+            const constraints = editor.storage?.resizableImage?.constraints || {};
+
+            if (minWidthInput && document.activeElement !== minWidthInput) {
+                const value = constraints.minWidth ?? '';
+                minWidthInput.value = value === '' ? '' : String(value);
+            }
+
+            if (maxWidthInput && document.activeElement !== maxWidthInput) {
+                const value = constraints.maxWidth ?? '';
+                maxWidthInput.value = value === '' ? '' : String(value);
+            }
         }
         
         function updateTableButtons() {
@@ -389,7 +546,70 @@
             tableButtons.appendChild(deleteTableBtn);
             
             toolbar.appendChild(tableButtons);
-            
+
+            const sizeGroup = document.createElement('div');
+            sizeGroup.className = 'toolbar-group image-size-group';
+
+            const sizeLabel = document.createElement('span');
+            sizeLabel.className = 'toolbar-group-label';
+            sizeLabel.textContent = '画像サイズ';
+            sizeGroup.appendChild(sizeLabel);
+
+            const minWrapper = document.createElement('label');
+            minWrapper.style.display = 'inline-flex';
+            minWrapper.style.alignItems = 'center';
+            minWrapper.style.gap = '4px';
+            minWrapper.textContent = '最小';
+
+            minWidthInput = document.createElement('input');
+            minWidthInput.type = 'number';
+            minWidthInput.min = '1';
+            minWidthInput.placeholder = 'px';
+            minWidthInput.setAttribute('aria-label', '画像の最小幅');
+            minWidthInput.addEventListener('change', () => {
+                if (!editor) return;
+                const raw = minWidthInput.value.trim();
+                const parsed = raw === '' ? null : Number(raw);
+                const payload = {
+                    minWidth: Number.isFinite(parsed) ? parsed : null,
+                };
+                editor.chain().focus().setImageResizeConstraints(payload).run();
+                updateToolbarState();
+            });
+            minWrapper.appendChild(minWidthInput);
+            sizeGroup.appendChild(minWrapper);
+
+            const separator = document.createElement('span');
+            separator.className = 'toolbar-group-separator';
+            separator.textContent = '〜';
+            sizeGroup.appendChild(separator);
+
+            const maxWrapper = document.createElement('label');
+            maxWrapper.style.display = 'inline-flex';
+            maxWrapper.style.alignItems = 'center';
+            maxWrapper.style.gap = '4px';
+            maxWrapper.textContent = '最大';
+
+            maxWidthInput = document.createElement('input');
+            maxWidthInput.type = 'number';
+            maxWidthInput.min = '1';
+            maxWidthInput.placeholder = 'px';
+            maxWidthInput.setAttribute('aria-label', '画像の最大幅');
+            maxWidthInput.addEventListener('change', () => {
+                if (!editor) return;
+                const raw = maxWidthInput.value.trim();
+                const parsed = raw === '' ? null : Number(raw);
+                const payload = {
+                    maxWidth: Number.isFinite(parsed) ? parsed : null,
+                };
+                editor.chain().focus().setImageResizeConstraints(payload).run();
+                updateToolbarState();
+            });
+            maxWrapper.appendChild(maxWidthInput);
+            sizeGroup.appendChild(maxWrapper);
+
+            toolbar.appendChild(sizeGroup);
+
             return toolbar;
         }
         
@@ -422,12 +642,18 @@
                         Placeholder.configure({
                             placeholder: 'ここに文章を入力してください...',
                         }),
-                        Image.configure({
+                        ResizableImage.configure({
                             inline: false,
                             allowBase64: false,
                             HTMLAttributes: {
                                 class: 'editor-image',
                                 loading: 'lazy',
+                            },
+                            resizeConstraints: {
+                                minWidth: 160,
+                                maxWidth: 720,
+                                minHeight: 120,
+                                maxHeight: 720,
                             },
                         }),
                         DriveImageExtension.configure({
@@ -475,7 +701,13 @@
                         updateToolbarState();
                     },
                 });
-                
+
+                if (editor) {
+                    editor.on('transaction', () => {
+                        updateToolbarState();
+                    });
+                }
+
                 // ローディング画面をエディターに置き換え
                 const root = document.getElementById('editor-root');
                 root.innerHTML = '';


### PR DESCRIPTION
## Summary
- add a ResizableImage extension that augments TipTap images with width/height attributes, resize handles, and runtime constraints
- update tiptap-image demo to use the new extension, expose toolbar inputs for constraint changes, and style the resizing UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1aaa3290832b958516a9a550726a