### PR TITLE
Fix view page asset path and Apps Script endpoint

### DIFF
--- a/view.html
+++ b/view.html
@@ -4,7 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Wikiページ表示</title>
-  <link rel="stylesheet" href="../styles/editor.css">
+  <link rel="stylesheet" href="./styles/editor.css">
+  <script>
+    (function ensureAppEndpoints() {
+      const defaults = {
+        wiki: 'https://script.google.com/macros/s/AKfycbxkzVroCbSCqvxaVyPjk-QZy6CMlvzXPnOHTWLH3HKUaqnSQRhKjl_mahsXf52qD2XZQ/exec',
+        driveImage: 'https://script.google.com/macros/s/AKfycbytAAym-sjES9hdBK_0LES7nQ6H4mwxCgADk7u9xY--YRIWlkEJrvK2FMHmJG74zQ7E/exec',
+      };
+
+      if (!window.APP_ENDPOINTS) {
+        window.APP_ENDPOINTS = defaults;
+        return;
+      }
+
+      window.APP_ENDPOINTS = {
+        ...defaults,
+        ...window.APP_ENDPOINTS,
+      };
+    })();
+  </script>
   <style>
     body {
       margin: 0;
@@ -162,7 +180,7 @@
 
     const WIKI_APPS_SCRIPT_ENDPOINT = (window.APP_ENDPOINTS && window.APP_ENDPOINTS.wiki)
       ? window.APP_ENDPOINTS.wiki
-      : 'https://script.google.com/macros/s/AKfycbzg5z7gt9ILWlVLFAt5vANfdAgi7kFbLa_K5w03Qt14IKfAJU3soOtf5dfIf6AVKjTIYg/exec';
+      : 'https://script.google.com/macros/s/AKfycbxkzVroCbSCqvxaVyPjk-QZy6CMlvzXPnOHTWLH3HKUaqnSQRhKjl_mahsXf52qD2XZQ/exec';
 
     function fetchWithoutPreflight(url, options = {}, timeout = DEFAULT_TIMEOUT) {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- load the shared editor stylesheet with the correct relative path on the wiki view page
- initialize Apps Script endpoint defaults during page load so the view uses the latest backend URL

## Testing
- no automated tests were run (static frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68df42513848832bb7c54cb9b2b7308e