### PR TITLE
Add CORS headers to JSON responses

### DIFF
--- a/wiki-backend.gs
+++ b/wiki-backend.gs
@@ -47,9 +47,18 @@ function doPost(e) {
 }
 
 function createJsonOutput(data) {
-  return ContentService
+  const textOutput = ContentService
     .createTextOutput(JSON.stringify(data))
     .setMimeType(ContentService.MimeType.JSON);
+
+  const allowedOrigins = CONFIG.ALLOWED_ORIGINS || [];
+  const originValue = allowedOrigins.length > 0 ? allowedOrigins[0] : '*';
+
+  textOutput.setHeader('Access-Control-Allow-Origin', originValue);
+  textOutput.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  textOutput.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+
+  return textOutput;
 }
 
 function parseRequestData(e) {


### PR DESCRIPTION
## Summary
- add CORS-related response headers in the Apps Script backend helper

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df464398a8832b9661627b7882885d