### PR TITLE
Add query-aware navigation between view and editor

### DIFF
--- a/tiptap-image2.html
+++ b/tiptap-image2.html
@@ -360,7 +360,7 @@
                 <div class="breadcrumb" id="breadcrumb"></div>
                 <div class="page-header-row">
                     <div class="input-group">
-                        <label class="input-label" for="page-name">ページ名（内部）</label>
+                        <label class="input-label" for="page-name">Page ID</label>
                         <input id="page-name" class="text-input" placeholder="sample-page" />
                     </div>
                     <div class="input-group" style="flex:1; min-width: 260px;">
@@ -368,8 +368,9 @@
                         <input id="page-title" class="text-input" placeholder="ページタイトル" />
                     </div>
                     <div class="header-actions">
-                        <button id="add-child-page" class="btn">子ページを追加</button>
-                        <button id="save-page" class="btn btn-primary">保存</button>
+                        <button id="add-child-page" class="btn" type="button">子ページを追加</button>
+                        <button id="save-page" class="btn btn-primary" type="button">保存</button>
+                        <button id="view-page" class="btn" type="button">ページを表示</button>
                     </div>
                 </div>
             </div>
@@ -435,6 +436,7 @@
             pageTitle: document.getElementById('page-title'),
             addChildPage: document.getElementById('add-child-page'),
             savePage: document.getElementById('save-page'),
+            viewPage: document.getElementById('view-page'),
             createRootPage: document.getElementById('create-root-page'),
             reloadPages: document.getElementById('reload-pages'),
             toolbar: document.getElementById('toolbar'),
@@ -445,6 +447,19 @@
 
         function normalizeSlug(value) {
             return value.trim().replace(/\s+/g, '-');
+        }
+
+        function getPageIdFromQuery() {
+            const params = new URLSearchParams(window.location.search);
+            const value = (params.get('page') || '').trim();
+            return value || null;
+        }
+
+        function updateHistory(pageId) {
+            const url = pageId
+                ? `${window.location.pathname}?page=${encodeURIComponent(pageId)}`
+                : window.location.pathname;
+            history.replaceState({ pageId }, '', url);
         }
 
         function getParentId(id) {
@@ -647,7 +662,7 @@
             }
         }
 
-        async function navigateToPage(id) {
+        async function navigateToPage(id, { updateHistory: shouldUpdateHistory = true } = {}) {
             if (!id) return;
             if (state.isNewPage && state.currentPageId === id) {
                 renderTree();
@@ -679,6 +694,9 @@
                 setStatus('ページを読み込みました', 'success');
                 updateBreadcrumb(page.id);
                 renderTree();
+                if (shouldUpdateHistory) {
+                    updateHistory(page.id);
+                }
             } catch (error) {
                 console.error('ページ読み込みエラー', error);
                 setStatus('ページの読み込みに失敗しました: ' + error.message, 'error');
@@ -785,6 +803,7 @@
             setUpdatedAt('');
             setStatus('新しいページを作成しました。保存して反映してください。');
             renderTree();
+            updateHistory(id);
         }
 
         function attachEventListeners() {
@@ -815,6 +834,24 @@
                         : state.currentPageId;
                     updateBreadcrumb(prospectiveId);
                 }
+            });
+            elements.viewPage.addEventListener('click', () => {
+                let targetId = state.currentPageId;
+                if (state.isNewPage) {
+                    const slug = normalizeSlug(elements.pageName.value || '');
+                    if (!slug) {
+                        alert('ページ名を入力してください。');
+                        elements.pageName.focus();
+                        return;
+                    }
+                    targetId = state.currentParentId ? `${state.currentParentId}/${slug}` : slug;
+                }
+                if (!targetId) {
+                    alert('ページを選択してください。');
+                    return;
+                }
+                const viewUrl = `./view.html?page=${encodeURIComponent(targetId)}`;
+                window.open(viewUrl, '_blank', 'noopener,noreferrer');
             });
             window.addEventListener('beforeunload', event => {
                 if (state.isDirty) {
@@ -882,7 +919,11 @@
         function initialize() {
             initEditor();
             attachEventListeners();
-            loadPages();
+            const initialPageId = getPageIdFromQuery();
+            if (initialPageId) {
+                updateHistory(initialPageId);
+            }
+            loadPages(initialPageId || undefined);
         }
 
         initialize();

--- a/view.html
+++ b/view.html
@@ -40,10 +40,37 @@
     .breadcrumb {
       font-size: 14px;
       color: #6b6b67;
-      margin-bottom: 12px;
       display: flex;
       flex-wrap: wrap;
       gap: 6px;
+    }
+
+    .view-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 12px;
+      gap: 16px;
+    }
+
+    .edit-button {
+      padding: 8px 14px;
+      border-radius: 6px;
+      border: 1px solid #d3d2ce;
+      background: #fff;
+      color: #37352f;
+      font-size: 13px;
+      cursor: pointer;
+      transition: background 0.2s, border 0.2s;
+    }
+
+    .edit-button:hover {
+      background: #f7f6f3;
+    }
+
+    .edit-button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
 
     .breadcrumb a {
@@ -161,7 +188,10 @@
 </head>
 <body>
   <div class="view-container">
-    <nav class="breadcrumb" id="breadcrumb"></nav>
+    <div class="view-header">
+      <nav class="breadcrumb" id="breadcrumb"></nav>
+      <button id="editPageButton" class="edit-button" type="button" disabled>編集</button>
+    </div>
     <div id="loader" class="loading-spinner"></div>
     <section class="page-card hidden" id="pageCard">
       <h1 class="page-title" id="pageTitle"></h1>
@@ -279,6 +309,7 @@
       childSection: document.getElementById('childPagesSection'),
       childList: document.getElementById('childPageList'),
       status: document.getElementById('statusMessage'),
+      editButton: document.getElementById('editPageButton'),
     };
 
     const normalizePageId = (pageId) => {
@@ -362,6 +393,8 @@
     async function displayPage(pageId) {
       const normalizedId = normalizePageId(pageId);
       renderBreadcrumb(normalizedId);
+      elements.editButton.dataset.pageId = normalizedId;
+      elements.editButton.disabled = false;
       showStatus('');
       elements.loader.classList.remove('hidden');
       elements.card.classList.add('hidden');
@@ -387,6 +420,7 @@
         elements.content.innerHTML = '';
         elements.childSection.classList.add('hidden');
         showStatus(error.message || 'ページの取得に失敗しました。', true);
+        elements.editButton.disabled = true;
       } finally {
         elements.loader.classList.add('hidden');
         elements.card.classList.remove('hidden');
@@ -423,6 +457,15 @@
     window.addEventListener('popstate', (event) => {
       const pageId = normalizePageId(event.state?.pageId || getPageIdFromQuery());
       void displayPage(pageId);
+    });
+
+    elements.editButton.addEventListener('click', () => {
+      const pageId = elements.editButton.dataset.pageId;
+      if (!pageId) {
+        return;
+      }
+      const url = `./tiptap-image2.html?page=${encodeURIComponent(pageId)}`;
+      window.location.href = url;
     });
 
     navigateTo(getPageIdFromQuery(), { replace: true });


### PR DESCRIPTION
## Summary
- allow the editor to load and update pages by ?page=<id> query parameters and expose a view button
- add an edit button in the viewer that links back to the editor with the current page id
- refresh labels/styles so the internal page identifier is shown as "Page ID"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df5ab08d84832b9ac562768534048c