### PR TITLE
Add centered loading overlay to editor operations

### DIFF
--- a/tiptap-image2.html
+++ b/tiptap-image2.html
@@ -192,6 +192,58 @@
             flex-direction: column;
         }
 
+        .loading-overlay {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(55, 53, 47, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            z-index: 1000;
+        }
+
+        .loading-overlay.visible {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .loading-popup {
+            background: #fff;
+            padding: 28px 36px;
+            border-radius: 14px;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 18px;
+            min-width: 260px;
+        }
+
+        .loading-spinner {
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            border: 4px solid #e9e9e7;
+            border-top-color: #2383e2;
+            animation: loading-spin 1s linear infinite;
+        }
+
+        @keyframes loading-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        .loading-message {
+            font-size: 15px;
+            color: #37352f;
+            font-weight: 500;
+            text-align: center;
+        }
+
         .editor-image {
             max-width: 100%;
             height: auto;
@@ -360,7 +412,7 @@
                 <div class="breadcrumb" id="breadcrumb"></div>
                 <div class="page-header-row">
                     <div class="input-group">
-                        <label class="input-label" for="page-name">ページ名（内部）</label>
+                        <label class="input-label" for="page-name">Page ID</label>
                         <input id="page-name" class="text-input" placeholder="sample-page" />
                     </div>
                     <div class="input-group" style="flex:1; min-width: 260px;">
@@ -368,8 +420,9 @@
                         <input id="page-title" class="text-input" placeholder="ページタイトル" />
                     </div>
                     <div class="header-actions">
-                        <button id="add-child-page" class="btn">子ページを追加</button>
-                        <button id="save-page" class="btn btn-primary">保存</button>
+                        <button id="add-child-page" class="btn" type="button">子ページを追加</button>
+                        <button id="save-page" class="btn btn-primary" type="button">保存</button>
+                        <button id="view-page" class="btn" type="button">ページを表示</button>
                     </div>
                 </div>
             </div>
@@ -386,6 +439,12 @@
                 <div id="updated-at" class="status-message"></div>
             </div>
         </main>
+        <div id="loading-overlay" class="loading-overlay" aria-live="polite" aria-busy="true" role="status">
+            <div class="loading-popup">
+                <div class="loading-spinner" aria-hidden="true"></div>
+                <div id="loading-message" class="loading-message">読み込み中...</div>
+            </div>
+        </div>
     </div>
 
     <script type="module">
@@ -435,16 +494,51 @@
             pageTitle: document.getElementById('page-title'),
             addChildPage: document.getElementById('add-child-page'),
             savePage: document.getElementById('save-page'),
+            viewPage: document.getElementById('view-page'),
             createRootPage: document.getElementById('create-root-page'),
             reloadPages: document.getElementById('reload-pages'),
             toolbar: document.getElementById('toolbar'),
             editor: document.getElementById('editor'),
             statusMessage: document.getElementById('status-message'),
-            updatedAt: document.getElementById('updated-at')
+            updatedAt: document.getElementById('updated-at'),
+            loadingOverlay: document.getElementById('loading-overlay'),
+            loadingMessage: document.getElementById('loading-message')
         };
+
+        const loadingState = {
+            count: 0
+        };
+
+        function beginLoading(message) {
+            loadingState.count += 1;
+            if (message) {
+                elements.loadingMessage.textContent = message;
+            }
+            elements.loadingOverlay.classList.add('visible');
+        }
+
+        function endLoading() {
+            loadingState.count = Math.max(loadingState.count - 1, 0);
+            if (loadingState.count === 0) {
+                elements.loadingOverlay.classList.remove('visible');
+            }
+        }
 
         function normalizeSlug(value) {
             return value.trim().replace(/\s+/g, '-');
+        }
+
+        function getPageIdFromQuery() {
+            const params = new URLSearchParams(window.location.search);
+            const value = (params.get('page') || '').trim();
+            return value || null;
+        }
+
+        function updateHistory(pageId) {
+            const url = pageId
+                ? `${window.location.pathname}?page=${encodeURIComponent(pageId)}`
+                : window.location.pathname;
+            history.replaceState({ pageId }, '', url);
         }
 
         function getParentId(id) {
@@ -630,6 +724,7 @@
         async function loadPages(selectId) {
             try {
                 setStatus('ページ一覧を読み込み中...');
+                beginLoading('ページ一覧を読み込み中...');
                 const pages = await dataService.getPages();
                 buildPageTree(pages);
                 renderTree();
@@ -644,10 +739,12 @@
             } catch (error) {
                 console.error('ページ一覧の読み込みに失敗しました', error);
                 setStatus('ページ一覧の読み込みに失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
             }
         }
 
-        async function navigateToPage(id) {
+        async function navigateToPage(id, { updateHistory: shouldUpdateHistory = true } = {}) {
             if (!id) return;
             if (state.isNewPage && state.currentPageId === id) {
                 renderTree();
@@ -658,6 +755,7 @@
             }
             try {
                 setStatus('ページを読み込み中...');
+                beginLoading('ページを読み込み中...');
                 const page = await dataService.getPage(id);
                 state.currentPageId = page.id;
                 state.currentParentId = getParentId(page.id);
@@ -679,9 +777,14 @@
                 setStatus('ページを読み込みました', 'success');
                 updateBreadcrumb(page.id);
                 renderTree();
+                if (shouldUpdateHistory) {
+                    updateHistory(page.id);
+                }
             } catch (error) {
                 console.error('ページ読み込みエラー', error);
                 setStatus('ページの読み込みに失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
             }
         }
 
@@ -729,6 +832,7 @@
 
             try {
                 setStatus('保存中です...');
+                beginLoading('保存しています...');
                 const response = await dataService.savePage(payload);
                 if (response.updatedAt) {
                     setUpdatedAt(`最終更新: ${new Date(response.updatedAt).toLocaleString('ja-JP')}`);
@@ -742,6 +846,8 @@
             } catch (error) {
                 console.error('保存エラー', error);
                 setStatus('保存に失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
             }
         }
 
@@ -785,6 +891,7 @@
             setUpdatedAt('');
             setStatus('新しいページを作成しました。保存して反映してください。');
             renderTree();
+            updateHistory(id);
         }
 
         function attachEventListeners() {
@@ -815,6 +922,24 @@
                         : state.currentPageId;
                     updateBreadcrumb(prospectiveId);
                 }
+            });
+            elements.viewPage.addEventListener('click', () => {
+                let targetId = state.currentPageId;
+                if (state.isNewPage) {
+                    const slug = normalizeSlug(elements.pageName.value || '');
+                    if (!slug) {
+                        alert('ページ名を入力してください。');
+                        elements.pageName.focus();
+                        return;
+                    }
+                    targetId = state.currentParentId ? `${state.currentParentId}/${slug}` : slug;
+                }
+                if (!targetId) {
+                    alert('ページを選択してください。');
+                    return;
+                }
+                const viewUrl = `./view.html?page=${encodeURIComponent(targetId)}`;
+                window.open(viewUrl, '_blank', 'noopener,noreferrer');
             });
             window.addEventListener('beforeunload', event => {
                 if (state.isDirty) {
@@ -882,7 +1007,11 @@
         function initialize() {
             initEditor();
             attachEventListeners();
-            loadPages();
+            const initialPageId = getPageIdFromQuery();
+            if (initialPageId) {
+                updateHistory(initialPageId);
+            }
+            loadPages(initialPageId || undefined);
         }
 
         initialize();

--- a/view.html
+++ b/view.html
@@ -40,10 +40,37 @@
     .breadcrumb {
       font-size: 14px;
       color: #6b6b67;
-      margin-bottom: 12px;
       display: flex;
       flex-wrap: wrap;
       gap: 6px;
+    }
+
+    .view-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 12px;
+      gap: 16px;
+    }
+
+    .edit-button {
+      padding: 8px 14px;
+      border-radius: 6px;
+      border: 1px solid #d3d2ce;
+      background: #fff;
+      color: #37352f;
+      font-size: 13px;
+      cursor: pointer;
+      transition: background 0.2s, border 0.2s;
+    }
+
+    .edit-button:hover {
+      background: #f7f6f3;
+    }
+
+    .edit-button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
 
     .breadcrumb a {
@@ -161,7 +188,10 @@
 </head>
 <body>
   <div class="view-container">
-    <nav class="breadcrumb" id="breadcrumb"></nav>
+    <div class="view-header">
+      <nav class="breadcrumb" id="breadcrumb"></nav>
+      <button id="editPageButton" class="edit-button" type="button" disabled>編集</button>
+    </div>
     <div id="loader" class="loading-spinner"></div>
     <section class="page-card hidden" id="pageCard">
       <h1 class="page-title" id="pageTitle"></h1>
@@ -279,6 +309,7 @@
       childSection: document.getElementById('childPagesSection'),
       childList: document.getElementById('childPageList'),
       status: document.getElementById('statusMessage'),
+      editButton: document.getElementById('editPageButton'),
     };
 
     const normalizePageId = (pageId) => {
@@ -362,6 +393,8 @@
     async function displayPage(pageId) {
       const normalizedId = normalizePageId(pageId);
       renderBreadcrumb(normalizedId);
+      elements.editButton.dataset.pageId = normalizedId;
+      elements.editButton.disabled = false;
       showStatus('');
       elements.loader.classList.remove('hidden');
       elements.card.classList.add('hidden');
@@ -387,6 +420,7 @@
         elements.content.innerHTML = '';
         elements.childSection.classList.add('hidden');
         showStatus(error.message || 'ページの取得に失敗しました。', true);
+        elements.editButton.disabled = true;
       } finally {
         elements.loader.classList.add('hidden');
         elements.card.classList.remove('hidden');
@@ -423,6 +457,15 @@
     window.addEventListener('popstate', (event) => {
       const pageId = normalizePageId(event.state?.pageId || getPageIdFromQuery());
       void displayPage(pageId);
+    });
+
+    elements.editButton.addEventListener('click', () => {
+      const pageId = elements.editButton.dataset.pageId;
+      if (!pageId) {
+        return;
+      }
+      const url = `./tiptap-image2.html?page=${encodeURIComponent(pageId)}`;
+      window.location.href = url;
     });
 
     navigateTo(getPageIdFromQuery(), { replace: true });


### PR DESCRIPTION
## Summary
- add a modal loading overlay with spinner to the editor so page load/save progress is clearly visible while keeping the status bar messaging
- hook editor data operations into the overlay with reference-counted begin/end helpers for nested requests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df5ab08d84832b9ac562768534048c