### PR TITLE
Append origin parameter to Apps Script requests

### DIFF
--- a/scripts/wikiDataService.js
+++ b/scripts/wikiDataService.js
@@ -85,9 +85,22 @@ export class WikiDataService {
     };
 
     let response;
+    let requestUrl = this.endpoint;
+    if (typeof window !== 'undefined' && window.location) {
+      try {
+        const url = new URL(this.endpoint);
+        if (!url.searchParams.has('origin')) {
+          url.searchParams.set('origin', window.location.origin);
+        }
+        requestUrl = url.toString();
+      } catch (error) {
+        console.warn('[WikiDataService] Failed to append origin to endpoint URL:', error);
+      }
+    }
+
     try {
       response = await fetchWithoutPreflight(
-        this.endpoint,
+        requestUrl,
         {
           method: 'POST',
           body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- append the current window origin to Apps Script request URLs to satisfy CORS expectations
- log a warning if the endpoint URL cannot be parsed while leaving the original URL intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df6f501c4c832b9c1f6143aed31515