### PR TITLE
Add inline link editing UI to TipTap page

### DIFF
--- a/tiptap-image3.html
+++ b/tiptap-image3.html
@@ -1,0 +1,1455 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wiki with TipTap</title>
+    <link rel="stylesheet" href="./styles/editor.css">
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            background: #f5f5f5;
+            color: #37352f;
+        }
+
+        .app-container {
+            display: flex;
+            height: 100vh;
+            width: 100vw;
+        }
+
+        .sidebar {
+            width: 280px;
+            background: #f7f6f3;
+            border-right: 1px solid #e9e9e7;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .sidebar-header {
+            padding: 20px 24px 12px;
+            border-bottom: 1px solid #e9e9e7;
+        }
+
+        .sidebar-title {
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .sidebar-actions {
+            display: flex;
+            gap: 8px;
+            padding: 12px 24px;
+            border-bottom: 1px solid #e9e9e7;
+        }
+
+        .sidebar-actions .btn {
+            flex: 1;
+        }
+
+        .page-tree {
+            flex: 1;
+            overflow-y: auto;
+            padding: 12px 8px 24px 16px;
+        }
+
+        .tree-list,
+        .tree-list ul {
+            list-style: none;
+            margin: 0;
+            padding-left: 16px;
+        }
+
+        .tree-list > li {
+            padding-left: 0;
+        }
+
+        .tree-item {
+            padding: 4px 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            color: #37352f;
+        }
+
+        .tree-item:hover {
+            background: #e9e9e7;
+        }
+
+        .tree-item.active {
+            background: #2383e2;
+            color: #fff;
+        }
+
+        .tree-item.dragging {
+            opacity: 0.5;
+        }
+
+        .tree-item.drop-target,
+        .tree-list.drop-target,
+        .tree-children.drop-target {
+            outline: 2px dashed #2383e2;
+            outline-offset: 2px;
+        }
+
+        .tree-children {
+            margin-left: 12px;
+            border-left: 1px solid #e0dfdc;
+            padding-left: 12px;
+        }
+
+        .main-area {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+        }
+
+        .page-header {
+            padding: 16px 32px;
+            border-bottom: 1px solid #e9e9e7;
+            background: #fff;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .page-header-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .input-group {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            min-width: 200px;
+        }
+
+        .input-label {
+            font-size: 12px;
+            font-weight: 600;
+            color: #6b6b67;
+        }
+
+        .text-input {
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid #d3d2ce;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        .text-input:disabled {
+            background: #f1f1ef;
+            color: #9b9a97;
+        }
+
+        .header-actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        .btn {
+            padding: 8px 14px;
+            border-radius: 6px;
+            border: 1px solid #d3d2ce;
+            background: #fff;
+            color: #37352f;
+            font-size: 13px;
+            cursor: pointer;
+            transition: background 0.2s, border 0.2s;
+        }
+
+        .btn:hover {
+            background: #f7f6f3;
+        }
+
+        .btn-primary {
+            background: #2383e2;
+            border-color: #2383e2;
+            color: #fff;
+        }
+
+        .btn-primary:hover {
+            background: #1a6bc2;
+        }
+
+        .editor-wrapper {
+            flex: 1;
+            overflow-y: auto;
+            padding: 32px;
+            background: #f8f8f7;
+        }
+
+        .editor-container {
+            max-width: 860px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .loading-overlay {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(55, 53, 47, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            z-index: 1000;
+        }
+
+        .loading-overlay.visible {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .loading-popup {
+            background: #fff;
+            padding: 28px 36px;
+            border-radius: 14px;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 18px;
+            min-width: 260px;
+        }
+
+        .loading-spinner {
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            border: 4px solid #e9e9e7;
+            border-top-color: #2383e2;
+            animation: loading-spin 1s linear infinite;
+        }
+
+        @keyframes loading-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        .loading-message {
+            font-size: 15px;
+            color: #37352f;
+            font-weight: 500;
+            text-align: center;
+        }
+
+        .editor-image {
+            max-width: 100%;
+            height: auto;
+            border-radius: 6px;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+        }
+
+        .resizable-image {
+            position: relative;
+            display: inline-block;
+            max-width: 100%;
+        }
+
+        .resizable-image img {
+            display: block;
+            max-width: 100%;
+            height: auto;
+        }
+
+        .resizable-image.is-selected img {
+            outline: 2px solid rgba(35, 131, 226, 0.5);
+            outline-offset: 2px;
+        }
+
+        .resize-handle {
+            position: absolute;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #2383e2;
+            border: 2px solid #fff;
+            box-shadow: 0 2px 6px rgba(15, 23, 42, 0.25);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            touch-action: none;
+            z-index: 5;
+        }
+
+        .resizable-image.is-selected .resize-handle {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .resize-handle-n { top: 0; left: 50%; transform: translate(-50%, -50%); cursor: ns-resize; }
+        .resize-handle-s { bottom: 0; left: 50%; transform: translate(-50%, 50%); cursor: ns-resize; }
+        .resize-handle-e { top: 50%; right: 0; transform: translate(50%, -50%); cursor: ew-resize; }
+        .resize-handle-w { top: 50%; left: 0; transform: translate(-50%, -50%); cursor: ew-resize; }
+        .resize-handle-ne { top: 0; right: 0; transform: translate(50%, -50%); cursor: nesw-resize; }
+        .resize-handle-nw { top: 0; left: 0; transform: translate(-50%, -50%); cursor: nwse-resize; }
+        .resize-handle-se { bottom: 0; right: 0; transform: translate(50%, 50%); cursor: nwse-resize; }
+        .resize-handle-sw { bottom: 0; left: 0; transform: translate(-50%, 50%); cursor: nesw-resize; }
+
+        .toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            padding: 16px;
+            border-bottom: 1px solid #edeceb;
+            background: #fafafa;
+        }
+
+        .toolbar button {
+            border: 1px solid transparent;
+            background: none;
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-size: 15px;
+            cursor: pointer;
+            color: #494848;
+        }
+
+        .toolbar button:hover {
+            background: #ececec;
+            border-color: #d0d0ce;
+        }
+
+        .toolbar button.active {
+            background: #2383e2;
+            color: #fff;
+            border-color: #2383e2;
+        }
+
+        .link-editor-bar {
+            display: none;
+            gap: 8px;
+            padding: 12px 16px;
+            border-bottom: 1px solid #edeceb;
+            background: #fff;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        .link-editor-bar.visible {
+            display: flex;
+        }
+
+        .link-editor-input {
+            flex: 1;
+            min-width: 200px;
+            padding: 8px 10px;
+            border-radius: 6px;
+            border: 1px solid #d0d0ce;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        .link-editor-actions {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+
+        .link-editor-bar button {
+            border: 1px solid #d0d0ce;
+            background: #fafafa;
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-size: 13px;
+            cursor: pointer;
+            color: #494848;
+            transition: background 0.2s, border 0.2s, color 0.2s;
+        }
+
+        .link-editor-bar button:hover {
+            background: #ececec;
+            border-color: #c0c0bd;
+        }
+
+        .link-target-toggle[aria-pressed="true"] {
+            background: #2383e2;
+            color: #fff;
+            border-color: #2383e2;
+        }
+
+        .editor-content {
+            padding: 24px 32px 48px;
+        }
+
+        .ProseMirror {
+            min-height: 400px;
+            outline: none;
+        }
+
+        .ProseMirror p.is-editor-empty:first-child::before {
+            content: attr(data-placeholder);
+            float: left;
+            color: #adb5bd;
+            pointer-events: none;
+            height: 0;
+        }
+
+        .status-bar {
+            padding: 10px 24px;
+            font-size: 13px;
+            border-top: 1px solid #e9e9e7;
+            background: #fff;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .status-message {
+            color: #6b6b67;
+        }
+
+        .status-message.status-success {
+            color: #2f8f2f;
+        }
+
+        .status-message.status-error {
+            color: #c0352b;
+        }
+
+        .breadcrumb {
+            font-size: 12px;
+            color: #9b9a97;
+        }
+
+        .breadcrumb span + span::before {
+            content: ' / ';
+            color: #c6c5c1;
+        }
+
+        .empty-state {
+            padding: 40px;
+            text-align: center;
+            color: #9b9a97;
+        }
+
+        @media (max-width: 960px) {
+            .app-container {
+                flex-direction: column;
+            }
+
+            .sidebar {
+                width: 100%;
+                height: 260px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="app-container">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div class="sidebar-title">ページ一覧</div>
+            </div>
+            <div class="sidebar-actions">
+                <button id="create-root-page" class="btn">新規ページ</button>
+                <button id="reload-pages" class="btn">再読み込み</button>
+            </div>
+            <div id="page-tree" class="page-tree"></div>
+        </aside>
+        <main class="main-area">
+            <div class="page-header">
+                <div class="breadcrumb" id="breadcrumb"></div>
+                <div class="page-header-row">
+                    <div class="input-group">
+                        <label class="input-label" for="page-name">Page ID</label>
+                        <input id="page-name" class="text-input" placeholder="sample-page" />
+                    </div>
+                    <div class="input-group" style="flex:1; min-width: 260px;">
+                        <label class="input-label" for="page-title">ページタイトル（表示）</label>
+                        <input id="page-title" class="text-input" placeholder="ページタイトル" />
+                    </div>
+                    <div class="header-actions">
+                        <button id="add-child-page" class="btn" type="button">子ページを追加</button>
+                        <button id="save-page" class="btn btn-primary" type="button">保存</button>
+                        <button id="view-page" class="btn" type="button">ページを表示</button>
+                    </div>
+                </div>
+            </div>
+            <div class="editor-wrapper">
+                <div class="editor-container">
+                    <div class="toolbar" id="toolbar"></div>
+                    <div class="link-editor-bar" id="link-editor-bar">
+                        <input id="link-editor-input" class="link-editor-input" type="text" placeholder="https://example.com" aria-label="リンク先URL" />
+                        <div class="link-editor-actions">
+                            <button id="link-target-toggle" class="link-target-toggle" type="button" aria-pressed="false" title="新しいタブで開く" aria-label="新しいタブで開く">
+                                ↗
+                            </button>
+                            <button id="link-apply" type="button" title="リンクを適用">適用</button>
+                            <button id="link-remove" type="button" title="リンクを解除">解除</button>
+                            <button id="link-cancel" type="button" title="リンク編集を閉じる">閉じる</button>
+                        </div>
+                    </div>
+                    <div class="editor-content">
+                        <div id="editor" class="editor"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="status-bar">
+                <div id="status-message" class="status-message"></div>
+                <div id="updated-at" class="status-message"></div>
+            </div>
+        </main>
+        <div id="loading-overlay" class="loading-overlay" aria-live="polite" aria-busy="true" role="status">
+            <div class="loading-popup">
+                <div class="loading-spinner" aria-hidden="true"></div>
+                <div id="loading-message" class="loading-message">読み込み中...</div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { Editor } from 'https://esm.sh/@tiptap/core';
+        import { StarterKit } from 'https://esm.sh/@tiptap/starter-kit';
+        import { Link } from 'https://esm.sh/@tiptap/extension-link';
+        import { Placeholder } from 'https://esm.sh/@tiptap/extension-placeholder';
+        import { Table } from 'https://esm.sh/@tiptap/extension-table';
+        import { TableRow } from 'https://esm.sh/@tiptap/extension-table-row';
+        import { TableCell } from 'https://esm.sh/@tiptap/extension-table-cell';
+        import { TableHeader } from 'https://esm.sh/@tiptap/extension-table-header';
+        import { ResizableImage } from 'https://brahmoon.github.io/wiki/extensions/resizableImage/ResizableImage.js';
+        import { DriveImageExtension } from 'https://brahmoon.github.io/wiki/extensions/driveImage/DriveImageExtension.js';
+        import { WikiDataService } from './scripts/wikiDataService.js';
+
+        /**
+         * Apps Script endpoints
+         * - wiki-backend.gs (spreadsheet storage)
+         * - extensions/driveImage/DriveImageAppsScript.gs (Drive image management)
+         */
+        const WIKI_APPS_SCRIPT_ENDPOINT = 'https://script.google.com/macros/s/AKfycbzT_UQFviPlT3SN4xwpDMiuJcGFRdvL--6bLBkwnmfasFC7fO_MbepMI1A8E-9_NxGaWg/exec';
+        const DRIVE_IMAGE_APPS_SCRIPT_ENDPOINT = 'https://script.google.com/macros/s/AKfycbytAAym-sjES9hdBK_0LES7nQ6H4mwxCgADk7u9xY--YRIWlkEJrvK2FMHmJG74zQ7E/exec';
+
+        const APPS_SCRIPT_ENDPOINT = WIKI_APPS_SCRIPT_ENDPOINT;
+
+        window.APP_ENDPOINTS = {
+          wiki: WIKI_APPS_SCRIPT_ENDPOINT,
+          driveImage: DRIVE_IMAGE_APPS_SCRIPT_ENDPOINT
+        };
+
+        const dataService = new WikiDataService({ endpoint: APPS_SCRIPT_ENDPOINT });
+
+        const state = {
+            editor: null,
+            isDirty: false,
+            pageTree: [],
+            pageMap: new Map(),
+            currentPageId: null,
+            currentParentId: null,
+            isNewPage: false,
+            isApplyingContent: false,
+            linkEditor: {
+                visible: false,
+                openInNewTab: false
+            }
+        };
+
+        const elements = {
+            pageTree: document.getElementById('page-tree'),
+            breadcrumb: document.getElementById('breadcrumb'),
+            pageName: document.getElementById('page-name'),
+            pageTitle: document.getElementById('page-title'),
+            addChildPage: document.getElementById('add-child-page'),
+            savePage: document.getElementById('save-page'),
+            viewPage: document.getElementById('view-page'),
+            createRootPage: document.getElementById('create-root-page'),
+            reloadPages: document.getElementById('reload-pages'),
+            toolbar: document.getElementById('toolbar'),
+            editor: document.getElementById('editor'),
+            statusMessage: document.getElementById('status-message'),
+            updatedAt: document.getElementById('updated-at'),
+            loadingOverlay: document.getElementById('loading-overlay'),
+            loadingMessage: document.getElementById('loading-message'),
+            linkEditorBar: document.getElementById('link-editor-bar'),
+            linkInput: document.getElementById('link-editor-input'),
+            linkTargetToggle: document.getElementById('link-target-toggle'),
+            linkApply: document.getElementById('link-apply'),
+            linkRemove: document.getElementById('link-remove'),
+            linkCancel: document.getElementById('link-cancel')
+        };
+
+        hideLinkEditor();
+
+        const loadingState = {
+            count: 0
+        };
+
+        const dragState = {
+            sourceId: null
+        };
+
+        function beginLoading(message) {
+            loadingState.count += 1;
+            if (message) {
+                elements.loadingMessage.textContent = message;
+            }
+            elements.loadingOverlay.classList.add('visible');
+        }
+
+        function endLoading() {
+            loadingState.count = Math.max(loadingState.count - 1, 0);
+            if (loadingState.count === 0) {
+                elements.loadingOverlay.classList.remove('visible');
+            }
+        }
+
+        function normalizeSlug(value) {
+            return value.trim().replace(/\s+/g, '-');
+        }
+
+        function isSlugTaken(parentId, slug, excludeId = null) {
+            if (!slug) {
+                return false;
+            }
+            const normalizedParent = parentId || null;
+            for (const node of state.pageMap.values()) {
+                if (excludeId && node.id === excludeId) {
+                    continue;
+                }
+                if (node.parentId === normalizedParent && node.slug === slug) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function generateUniqueSlug(parentId, baseSlug, excludeId = null) {
+            const normalizedBase = normalizeSlug(baseSlug || '');
+            const candidateBase = normalizedBase || 'page';
+            let candidate = candidateBase;
+            let index = 2;
+            while (isSlugTaken(parentId, candidate, excludeId)) {
+                candidate = `${candidateBase}${index}`;
+                index += 1;
+            }
+            return candidate;
+        }
+
+        function isDescendantId(id, potentialAncestor) {
+            if (!id || !potentialAncestor) {
+                return false;
+            }
+            return id === potentialAncestor || id.startsWith(`${potentialAncestor}/`);
+        }
+
+        function updateProvisionalPageId(slug) {
+            if (!state.isNewPage || !state.currentPageId) {
+                return;
+            }
+            const normalizedSlug = slug || '';
+            const parentId = state.currentParentId;
+            const newId = normalizedSlug
+                ? (parentId ? `${parentId}/${normalizedSlug}` : normalizedSlug)
+                : null;
+            const oldId = state.currentPageId;
+            if (!newId || newId === oldId) {
+                return;
+            }
+            if (isSlugTaken(parentId, normalizedSlug, oldId)) {
+                return;
+            }
+            const node = state.pageMap.get(oldId);
+            if (!node) {
+                return;
+            }
+            removeNode(oldId);
+            node.id = newId;
+            node.slug = normalizedSlug;
+            node.parentId = parentId || null;
+            insertNode(node);
+            state.currentPageId = newId;
+            renderTree();
+        }
+
+        function getPageIdFromQuery() {
+            const params = new URLSearchParams(window.location.search);
+            const value = (params.get('page') || '').trim();
+            return value || null;
+        }
+
+        function updateHistory(pageId) {
+            const url = pageId
+                ? `${window.location.pathname}?page=${encodeURIComponent(pageId)}`
+                : window.location.pathname;
+            history.replaceState({ pageId }, '', url);
+        }
+
+        function getParentId(id) {
+            if (!id) return null;
+            const parts = id.split('/');
+            parts.pop();
+            return parts.length ? parts.join('/') : null;
+        }
+
+        function getSlug(id) {
+            if (!id) return '';
+            const parts = id.split('/');
+            return parts.pop();
+        }
+
+        function updateBreadcrumb(id) {
+            elements.breadcrumb.innerHTML = '';
+            if (!id) return;
+            const fragments = id.split('/');
+            const parts = [];
+            for (let i = 0; i < fragments.length; i++) {
+                const segment = fragments.slice(0, i + 1).join('/');
+                parts.push({ id: segment, label: state.pageMap.get(segment)?.title || fragments[i] });
+            }
+            parts.forEach((part, index) => {
+                const span = document.createElement('span');
+                span.textContent = part.label || part.id;
+                span.dataset.id = part.id;
+                span.style.cursor = 'pointer';
+                span.addEventListener('click', () => {
+                    if (state.currentPageId === part.id) return;
+                    navigateToPage(part.id);
+                });
+                elements.breadcrumb.appendChild(span);
+            });
+        }
+
+        function createToolbarButton(label, command, isActive, tooltip) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.addEventListener('click', command);
+            if (tooltip) {
+                button.title = tooltip;
+            }
+            if (isActive && isActive()) {
+                button.classList.add('active');
+            }
+            return button;
+        }
+
+        function renderToolbar() {
+            elements.toolbar.innerHTML = '';
+            const editor = state.editor;
+            if (!editor) return;
+
+            const buttons = [
+                createToolbarButton('B', () => editor.chain().focus().toggleBold().run(), () => editor.isActive('bold'), '太字'),
+                createToolbarButton('I', () => editor.chain().focus().toggleItalic().run(), () => editor.isActive('italic'), '斜体'),
+                createToolbarButton('🔗', handleLinkButtonClick, () => editor.isActive('link'), 'リンクを挿入/編集'),
+                createToolbarButton('H1', () => editor.chain().focus().toggleHeading({ level: 1 }).run(), () => editor.isActive('heading', { level: 1 }), '見出し 1'),
+                createToolbarButton('H2', () => editor.chain().focus().toggleHeading({ level: 2 }).run(), () => editor.isActive('heading', { level: 2 }), '見出し 2'),
+                createToolbarButton('H3', () => editor.chain().focus().toggleHeading({ level: 3 }).run(), () => editor.isActive('heading', { level: 3 }), '見出し 3'),
+                createToolbarButton('UL', () => editor.chain().focus().toggleBulletList().run(), () => editor.isActive('bulletList'), '箇条書きリスト'),
+                createToolbarButton('OL', () => editor.chain().focus().toggleOrderedList().run(), () => editor.isActive('orderedList'), '番号付きリスト'),
+                createToolbarButton('""', () => editor.chain().focus().toggleBlockquote().run(), () => editor.isActive('blockquote'), '引用'),
+                createToolbarButton('コード', () => editor.chain().focus().toggleCodeBlock().run(), () => editor.isActive('codeBlock'), 'コードブロック'),
+                createToolbarButton('表', () => editor.chain().focus().insertTable({ rows: 3, cols: 3 }).run(), () => false, '表を挿入')
+            ];
+
+            const driveImageButton = createToolbarButton('🖼️', () => editor.commands.openImageModal(), () => false, 'Drive画像を挿入');
+            buttons.push(driveImageButton);
+
+            buttons.forEach(button => elements.toolbar.appendChild(button));
+
+            if (state.linkEditor.visible) {
+                syncLinkEditorFromSelection();
+            }
+        }
+
+        function updateLinkTargetToggle() {
+            const pressed = state.linkEditor.openInNewTab;
+            const label = pressed ? '新しいタブで開く（ON）' : '新しいタブで開く';
+            elements.linkTargetToggle.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+            elements.linkTargetToggle.title = label;
+            elements.linkTargetToggle.setAttribute('aria-label', label);
+        }
+
+        function showLinkEditor() {
+            state.linkEditor.visible = true;
+            elements.linkEditorBar.classList.add('visible');
+            updateLinkTargetToggle();
+        }
+
+        function hideLinkEditor() {
+            state.linkEditor.visible = false;
+            elements.linkEditorBar.classList.remove('visible');
+            elements.linkInput.value = '';
+            state.linkEditor.openInNewTab = false;
+            updateLinkTargetToggle();
+        }
+
+        function handleLinkButtonClick() {
+            const editor = state.editor;
+            if (!editor) return;
+            const attrs = editor.getAttributes('link') || {};
+            elements.linkInput.value = attrs.href || '';
+            state.linkEditor.openInNewTab = attrs.target === '_blank';
+            showLinkEditor();
+            requestAnimationFrame(() => elements.linkInput.focus());
+        }
+
+        function applyLinkFromEditor() {
+            const editor = state.editor;
+            if (!editor) return;
+            const href = (elements.linkInput.value || '').trim();
+            const chain = editor.chain().focus();
+            if (!href) {
+                chain.extendMarkRange('link').unsetLink().run();
+                hideLinkEditor();
+                return;
+            }
+            const attributes = { href };
+            if (state.linkEditor.openInNewTab) {
+                attributes.target = '_blank';
+                attributes.rel = 'noopener noreferrer';
+            } else {
+                attributes.target = null;
+                attributes.rel = null;
+            }
+            chain.extendMarkRange('link').setLink(attributes).run();
+            hideLinkEditor();
+        }
+
+        function removeLinkFromSelection() {
+            const editor = state.editor;
+            if (!editor) return;
+            editor.chain().focus().extendMarkRange('link').unsetLink().run();
+            hideLinkEditor();
+        }
+
+        function syncLinkEditorFromSelection() {
+            if (!state.linkEditor.visible) {
+                return;
+            }
+            const editor = state.editor;
+            if (!editor) {
+                return;
+            }
+            const attrs = editor.getAttributes('link') || {};
+            if (attrs.href) {
+                elements.linkInput.value = attrs.href;
+                state.linkEditor.openInNewTab = attrs.target === '_blank';
+                updateLinkTargetToggle();
+            }
+        }
+
+        function buildPageTree(pages) {
+            const map = new Map();
+            pages.forEach(page => {
+                const node = {
+                    id: page.id,
+                    title: page.title || '無題',
+                    updatedAt: page.updatedAt || '',
+                    parentId: getParentId(page.id),
+                    slug: getSlug(page.id),
+                    children: []
+                };
+                map.set(node.id, node);
+            });
+
+            const roots = [];
+            map.forEach(node => {
+                if (node.parentId && map.has(node.parentId)) {
+                    map.get(node.parentId).children.push(node);
+                } else {
+                    roots.push(node);
+                }
+            });
+
+            const sortNodes = nodes => {
+                nodes.sort((a, b) => a.title.localeCompare(b.title, 'ja'));
+                nodes.forEach(child => sortNodes(child.children));
+            };
+
+            sortNodes(roots);
+
+            state.pageMap = map;
+            state.pageTree = roots;
+        }
+
+        function insertNode(node) {
+            state.pageMap.set(node.id, node);
+            if (node.parentId && state.pageMap.has(node.parentId)) {
+                const parent = state.pageMap.get(node.parentId);
+                parent.children.push(node);
+                parent.children.sort((a, b) => a.title.localeCompare(b.title, 'ja'));
+            } else {
+                state.pageTree.push(node);
+                state.pageTree.sort((a, b) => a.title.localeCompare(b.title, 'ja'));
+            }
+        }
+
+        function removeNode(id) {
+            const node = state.pageMap.get(id);
+            if (!node) return;
+            if (node.parentId && state.pageMap.has(node.parentId)) {
+                const parent = state.pageMap.get(node.parentId);
+                parent.children = parent.children.filter(child => child.id !== id);
+            } else {
+                state.pageTree = state.pageTree.filter(root => root.id !== id);
+            }
+            state.pageMap.delete(id);
+        }
+
+        function createTreeList(parentId) {
+            const list = document.createElement('ul');
+            list.className = parentId ? 'tree-children' : 'tree-list';
+            list.dataset.parentId = parentId || '';
+            list.addEventListener('dragover', handleListDragOver);
+            list.addEventListener('dragleave', handleListDragLeave);
+            list.addEventListener('drop', handleListDrop);
+            return list;
+        }
+
+        function handleListDragOver(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const parentId = event.currentTarget.dataset.parentId || '';
+            if (parentId && isDescendantId(parentId, dragState.sourceId)) {
+                return;
+            }
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            event.currentTarget.classList.add('drop-target');
+        }
+
+        function handleListDragLeave(event) {
+            event.currentTarget.classList.remove('drop-target');
+        }
+
+        function handleListDrop(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const parentId = event.currentTarget.dataset.parentId || '';
+            event.currentTarget.classList.remove('drop-target');
+            if (parentId && isDescendantId(parentId, dragState.sourceId)) {
+                setStatus('子ページの下へは移動できません。', 'error');
+                return;
+            }
+            movePage(dragState.sourceId, parentId ? parentId : null);
+        }
+
+        function handleDragStart(event) {
+            const id = event.currentTarget.dataset.id;
+            if (!id) {
+                return;
+            }
+            dragState.sourceId = id;
+            event.dataTransfer.setData('text/plain', id);
+            event.dataTransfer.effectAllowed = 'move';
+            event.currentTarget.classList.add('dragging');
+        }
+
+        function handleDragEnd(event) {
+            event.currentTarget.classList.remove('dragging');
+            dragState.sourceId = null;
+            clearDropIndicators();
+        }
+
+        function handleItemDragEnter(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const targetId = event.currentTarget.dataset.id;
+            if (!targetId || targetId === dragState.sourceId || isDescendantId(targetId, dragState.sourceId)) {
+                return;
+            }
+            event.currentTarget.classList.add('drop-target');
+        }
+
+        function handleItemDragLeave(event) {
+            event.currentTarget.classList.remove('drop-target');
+        }
+
+        function handleItemDragOver(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const targetId = event.currentTarget.dataset.id;
+            if (!targetId || targetId === dragState.sourceId || isDescendantId(targetId, dragState.sourceId)) {
+                return;
+            }
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+        }
+
+        function handleItemDrop(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const targetId = event.currentTarget.dataset.id;
+            event.currentTarget.classList.remove('drop-target');
+            if (!targetId || targetId === dragState.sourceId || isDescendantId(targetId, dragState.sourceId)) {
+                return;
+            }
+            movePage(dragState.sourceId, targetId);
+        }
+
+        function clearDropIndicators() {
+            document.querySelectorAll('.drop-target').forEach(el => el.classList.remove('drop-target'));
+        }
+
+        function renderTree() {
+            elements.pageTree.innerHTML = '';
+            if (!state.pageTree.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'ページがありません。「新規ページ」を押して作成してください。';
+                elements.pageTree.appendChild(empty);
+                return;
+            }
+
+            const list = createTreeList(null);
+            state.pageTree.forEach(node => list.appendChild(renderTreeNode(node)));
+            elements.pageTree.appendChild(list);
+        }
+
+        function renderTreeNode(node) {
+            const item = document.createElement('li');
+            const label = document.createElement('div');
+            label.className = 'tree-item';
+            if (node.id === state.currentPageId) {
+                label.classList.add('active');
+            }
+            label.textContent = node.title;
+            label.dataset.id = node.id;
+            label.draggable = true;
+            label.addEventListener('click', () => navigateToPage(node.id));
+            label.addEventListener('dragstart', handleDragStart);
+            label.addEventListener('dragend', handleDragEnd);
+            label.addEventListener('dragenter', handleItemDragEnter);
+            label.addEventListener('dragleave', handleItemDragLeave);
+            label.addEventListener('dragover', handleItemDragOver);
+            label.addEventListener('drop', handleItemDrop);
+            item.appendChild(label);
+
+            const childList = createTreeList(node.id);
+            node.children.forEach(child => childList.appendChild(renderTreeNode(child)));
+            item.appendChild(childList);
+
+            return item;
+        }
+
+        async function movePage(pageId, newParentId) {
+            if (!pageId) {
+                return;
+            }
+            const node = state.pageMap.get(pageId);
+            if (!node) {
+                return;
+            }
+            if (state.isNewPage && state.currentPageId === pageId) {
+                alert('新規ページは保存後に移動してください。');
+                return;
+            }
+            if (state.isDirty && state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                alert('未保存の変更があります。保存してから移動してください。');
+                return;
+            }
+
+            const parentId = newParentId || null;
+            const baseSlug = node.slug || getSlug(pageId);
+            const uniqueSlug = generateUniqueSlug(parentId, baseSlug, pageId);
+            const newId = parentId ? `${parentId}/${uniqueSlug}` : uniqueSlug;
+
+            if (newId === pageId) {
+                return;
+            }
+
+            try {
+                clearDropIndicators();
+                setStatus('ページを移動しています...');
+                beginLoading('ページを移動しています...');
+                await dataService.renamePageTree({ originalId: pageId, newId });
+                let nextSelection = null;
+                if (state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                    const suffix = state.currentPageId.substring(pageId.length);
+                    nextSelection = newId + suffix;
+                }
+                await loadPages(nextSelection || undefined);
+                setStatus('ページを移動しました', 'success');
+            } catch (error) {
+                console.error('ページ移動エラー', error);
+                setStatus('ページの移動に失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        function setStatus(message, type = 'info') {
+            elements.statusMessage.textContent = message || '';
+            elements.statusMessage.classList.remove('status-success', 'status-error');
+            if (type === 'success') {
+                elements.statusMessage.classList.add('status-success');
+            } else if (type === 'error') {
+                elements.statusMessage.classList.add('status-error');
+            }
+        }
+
+        function setUpdatedAt(text) {
+            elements.updatedAt.textContent = text || '';
+        }
+
+        async function loadPages(selectId) {
+            try {
+                setStatus('ページ一覧を読み込み中...');
+                beginLoading('ページ一覧を読み込み中...');
+                const pages = await dataService.getPages();
+                buildPageTree(pages);
+                renderTree();
+                setStatus('ページ一覧を更新しました', 'success');
+                if (selectId) {
+                    await navigateToPage(selectId);
+                } else if (!state.currentPageId && pages.length) {
+                    await navigateToPage(pages[0].id);
+                } else {
+                    renderTree();
+                }
+            } catch (error) {
+                console.error('ページ一覧の読み込みに失敗しました', error);
+                setStatus('ページ一覧の読み込みに失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        async function navigateToPage(id, { updateHistory: shouldUpdateHistory = true } = {}) {
+            if (!id) return;
+            if (state.isNewPage && state.currentPageId === id) {
+                renderTree();
+                return;
+            }
+            if (state.isDirty && !confirm('未保存の変更があります。ページを切り替えますか？')) {
+                return;
+            }
+            try {
+                setStatus('ページを読み込み中...');
+                beginLoading('ページを読み込み中...');
+                const page = await dataService.getPage(id);
+                state.currentPageId = page.id;
+                state.currentParentId = getParentId(page.id);
+                state.isNewPage = false;
+                state.isDirty = false;
+                if (state.pageMap.has(page.id)) {
+                    const node = state.pageMap.get(page.id);
+                    node.title = page.title || '無題';
+                    node.updatedAt = page.updatedAt || '';
+                }
+                const slug = getSlug(page.id);
+                elements.pageName.value = slug;
+                elements.pageName.disabled = false;
+                elements.pageTitle.value = page.title || '無題';
+                state.isApplyingContent = true;
+                state.editor.commands.setContent(page.content || '', false);
+                state.isApplyingContent = false;
+                hideLinkEditor();
+                renderToolbar();
+                setUpdatedAt(page.updatedAt ? `最終更新: ${new Date(page.updatedAt).toLocaleString('ja-JP')}` : '');
+                setStatus('ページを読み込みました', 'success');
+                updateBreadcrumb(page.id);
+                renderTree();
+                if (shouldUpdateHistory) {
+                    updateHistory(page.id);
+                }
+            } catch (error) {
+                console.error('ページ読み込みエラー', error);
+                setStatus('ページの読み込みに失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        function prepareToolbarUpdates() {
+            if (!state.editor) return;
+            state.editor.on('update', () => {
+                if (!state.isApplyingContent) {
+                    state.isDirty = true;
+                }
+                renderToolbar();
+                syncLinkEditorFromSelection();
+            });
+            state.editor.on('selectionUpdate', () => {
+                renderToolbar();
+                syncLinkEditorFromSelection();
+            });
+        }
+
+        async function saveCurrentPage() {
+            let slugInput = normalizeSlug(elements.pageName.value || '');
+            const titleInput = elements.pageTitle.value.trim();
+            if (!slugInput) {
+                alert('ページ名を入力してください。');
+                elements.pageName.focus();
+                return;
+            }
+
+            const parentId = state.currentParentId;
+            const id = parentId ? `${parentId}/${slugInput}` : slugInput;
+
+            if (isSlugTaken(parentId, slugInput, state.currentPageId)) {
+                alert('同じページ名のページが既に存在します。別の名前を指定してください。');
+                return;
+            }
+
+            const payload = {
+                id,
+                title: titleInput || slugInput,
+                content: state.editor.getHTML()
+            };
+
+            try {
+                setStatus('保存中です...');
+                beginLoading('保存しています...');
+                if (!state.isNewPage && state.currentPageId && id !== state.currentPageId) {
+                    elements.loadingMessage.textContent = 'ページIDを更新しています...';
+                    await dataService.renamePageTree({ originalId: state.currentPageId, newId: id });
+                    state.currentPageId = id;
+                    state.currentParentId = parentId || null;
+                    elements.loadingMessage.textContent = '保存しています...';
+                }
+                const response = await dataService.savePage(payload);
+                if (response.updatedAt) {
+                    setUpdatedAt(`最終更新: ${new Date(response.updatedAt).toLocaleString('ja-JP')}`);
+                }
+                state.isDirty = false;
+                state.isNewPage = false;
+                state.currentPageId = id;
+                state.currentParentId = parentId || null;
+                slugInput = normalizeSlug(slugInput);
+                elements.pageName.value = slugInput;
+                elements.pageName.disabled = false;
+                await loadPages(id);
+                setStatus('保存しました', 'success');
+            } catch (error) {
+                console.error('保存エラー', error);
+                setStatus('保存に失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        function createNewPage(parentId = null) {
+            const defaultName = parentId ? `${getSlug(parentId)}-child` : 'new-page';
+            const pageName = normalizeSlug(prompt('ページ名（内部識別子）を入力してください', defaultName) || '');
+            if (!pageName) {
+                return;
+            }
+            if (state.isNewPage && state.currentPageId) {
+                removeNode(state.currentPageId);
+            }
+            const pageTitle = prompt('ページタイトル（表示名）を入力してください', pageName) || pageName;
+            const id = parentId ? `${parentId}/${pageName}` : pageName;
+            if (isSlugTaken(parentId, pageName, state.currentPageId)) {
+                alert('同じページ名のページが既に存在します。別の名前を指定してください。');
+                return;
+            }
+
+            state.currentParentId = parentId;
+            state.currentPageId = id;
+            state.isNewPage = true;
+            state.isDirty = true;
+            elements.pageName.disabled = false;
+            elements.pageName.value = pageName;
+            elements.pageTitle.value = pageTitle;
+            state.isApplyingContent = true;
+            state.editor.commands.setContent('', false);
+            state.isApplyingContent = false;
+            hideLinkEditor();
+            renderToolbar();
+            const node = {
+                id,
+                title: pageTitle || '無題',
+                updatedAt: '',
+                parentId,
+                slug: pageName,
+                children: []
+            };
+            insertNode(node);
+            updateBreadcrumb(id);
+            setUpdatedAt('');
+            setStatus('新しいページを作成しました。保存して反映してください。');
+            renderTree();
+            updateHistory(id);
+        }
+
+        function attachEventListeners() {
+            elements.savePage.addEventListener('click', saveCurrentPage);
+            elements.createRootPage.addEventListener('click', () => createNewPage(null));
+            elements.addChildPage.addEventListener('click', () => {
+                if (!state.currentPageId) {
+                    alert('子ページを作成する親ページを選択してください。');
+                    return;
+                }
+                createNewPage(state.currentPageId);
+            });
+            elements.reloadPages.addEventListener('click', () => loadPages(state.currentPageId));
+            elements.pageTitle.addEventListener('input', () => {
+                state.isDirty = true;
+                if (state.isNewPage && state.currentPageId && state.pageMap.has(state.currentPageId)) {
+                    const node = state.pageMap.get(state.currentPageId);
+                    node.title = elements.pageTitle.value.trim() || node.slug || '無題';
+                    renderTree();
+                }
+            });
+            elements.pageName.addEventListener('input', () => {
+                const slug = normalizeSlug(elements.pageName.value || '');
+                if (elements.pageName.value !== slug) {
+                    elements.pageName.value = slug;
+                    if (document.activeElement === elements.pageName) {
+                        const position = slug.length;
+                        elements.pageName.setSelectionRange(position, position);
+                    }
+                }
+                state.isDirty = true;
+                if (state.isNewPage) {
+                    updateProvisionalPageId(slug);
+                }
+                const prospectiveId = slug
+                    ? (state.currentParentId ? `${state.currentParentId}/${slug}` : slug)
+                    : state.currentPageId;
+                updateBreadcrumb(prospectiveId);
+            });
+            elements.viewPage.addEventListener('click', () => {
+                let targetId = state.currentPageId;
+                if (state.isNewPage) {
+                    const slug = normalizeSlug(elements.pageName.value || '');
+                    if (!slug) {
+                        alert('ページ名を入力してください。');
+                        elements.pageName.focus();
+                        return;
+                    }
+                    targetId = state.currentParentId ? `${state.currentParentId}/${slug}` : slug;
+                }
+                if (!targetId) {
+                    alert('ページを選択してください。');
+                    return;
+                }
+                const viewUrl = `./view.html?page=${encodeURIComponent(targetId)}`;
+                window.open(viewUrl, '_blank', 'noopener,noreferrer');
+            });
+            elements.linkTargetToggle.addEventListener('click', () => {
+                state.linkEditor.openInNewTab = !state.linkEditor.openInNewTab;
+                updateLinkTargetToggle();
+            });
+            elements.linkApply.addEventListener('click', applyLinkFromEditor);
+            elements.linkRemove.addEventListener('click', removeLinkFromSelection);
+            elements.linkCancel.addEventListener('click', () => {
+                hideLinkEditor();
+                state.editor?.commands.focus();
+            });
+            elements.linkInput.addEventListener('keydown', event => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    applyLinkFromEditor();
+                } else if (event.key === 'Escape') {
+                    event.preventDefault();
+                    hideLinkEditor();
+                    state.editor?.commands.focus();
+                }
+            });
+            window.addEventListener('beforeunload', event => {
+                if (state.isDirty) {
+                    event.preventDefault();
+                    event.returnValue = '';
+                }
+            });
+        }
+
+        function initEditor() {
+            state.editor = new Editor({
+                element: elements.editor,
+                extensions: [
+                    StarterKit.configure({
+                        heading: {
+                            levels: [1, 2, 3]
+                        }
+                    }),
+                    Placeholder.configure({
+                        placeholder: 'ここにコンテンツを入力してください...'
+                    }),
+                    Link.configure({
+                        openOnClick: false,
+                        autolink: true,
+                        linkOnPaste: true
+                    }),
+                    Table.configure({ resizable: true }),
+                    TableRow,
+                    TableHeader,
+                    TableCell,
+                    ResizableImage.configure({
+                        inline: false,
+                        allowBase64: false,
+                        HTMLAttributes: {
+                            class: 'editor-image',
+                            loading: 'lazy'
+                        },
+                        resizeConstraints: {
+                            minShortSide: 200,
+                            maxLongSide: 860
+                        }
+                    }),
+                    DriveImageExtension.configure({
+                        webAppUrl: DRIVE_IMAGE_APPS_SCRIPT_ENDPOINT,
+                        maxFileSize: 10 * 1024 * 1024,
+                        allowedMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
+                        uploadTimeout: 45000,
+                        maxConcurrentUploads: 2,
+                        galleryTimeout: 20000,
+                        galleryCacheTimeout: 0,
+                        enablePasteUpload: true,
+                        enableDropUpload: true,
+                        addToToolbar: false,
+                        toolbarSelector: '.toolbar',
+                        buttonClass: 'btn',
+                        debug: false
+                    })
+                ],
+                content: '',
+                onUpdate() {
+                    if (!state.isApplyingContent) {
+                        state.isDirty = true;
+                    }
+                }
+            });
+            renderToolbar();
+            prepareToolbarUpdates();
+        }
+
+        function initialize() {
+            initEditor();
+            attachEventListeners();
+            const initialPageId = getPageIdFromQuery();
+            if (initialPageId) {
+                updateHistory(initialPageId);
+            }
+            loadPages(initialPageId || undefined);
+        }
+
+        initialize();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `tiptap-image3.html` page with an inline link editor bar that surfaces URL entry, new-tab toggles, and apply/remove controls under the toolbar
- integrate the TipTap Link extension, a dedicated link toolbar button, and hover tooltips across toolbar buttons to improve discoverability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df816023e0832b856cba39c0d274e2