### PR TITLE
Add TipTap template builder UI with Apps Script backend

### DIFF
--- a/extensions/templateBuilder/TemplateBuilderExtension.js
+++ b/extensions/templateBuilder/TemplateBuilderExtension.js
@@ -1,0 +1,1124 @@
+import { Extension } from 'https://esm.sh/@tiptap/core';
+
+const BREAKPOINTS = ['base', 'desktop', 'tablet', 'mobile'];
+const BREAKPOINT_LABELS = {
+  base: 'Base',
+  desktop: 'Desktop',
+  tablet: 'Tablet',
+  mobile: 'Mobile',
+};
+
+const NODE_DEFINITIONS = {
+  group: {
+    label: 'グループ',
+    description: 'レイアウトコンテナ。子要素を並べます。',
+    defaultProps: {
+      display: 'flex',
+      direction: 'row',
+      justify: 'flex-start',
+      align: 'stretch',
+      gap: '16px',
+      padding: '16px',
+      width: '100%'
+    },
+    properties: [
+      { key: 'direction', label: '配置方向', type: 'select', options: ['row', 'column'] },
+      { key: 'justify', label: '水平揃え', type: 'select', options: ['flex-start', 'center', 'flex-end', 'space-between', 'space-around'] },
+      { key: 'align', label: '垂直揃え', type: 'select', options: ['stretch', 'flex-start', 'center', 'flex-end'] },
+      { key: 'gap', label: '要素間隔', type: 'text', placeholder: '16px' },
+      { key: 'padding', label: 'パディング', type: 'text', placeholder: '16px 24px' },
+      { key: 'background', label: '背景色', type: 'text', placeholder: '#ffffff' },
+      { key: 'border', label: '境界線', type: 'text', placeholder: '1px solid #e5e7eb' },
+      { key: 'borderRadius', label: '角丸', type: 'text', placeholder: '8px' }
+    ],
+    allowChildren: ['group', 'text', 'image', 'button', 'divider']
+  },
+  text: {
+    label: 'テキスト',
+    description: '文章やタイトルに利用します。',
+    defaultProps: {
+      tag: 'p',
+      content: 'サンプルテキスト',
+      fontSize: '16px',
+      color: '#1f2937',
+      fontWeight: '400',
+      lineHeight: '1.6',
+      margin: '0',
+      bindingKey: 'text'
+    },
+    properties: [
+      { key: 'content', label: '初期テキスト', type: 'textarea' },
+      { key: 'bindingKey', label: 'テキスト差替キー', type: 'text', placeholder: 'title' },
+      { key: 'tag', label: 'タグ', type: 'select', options: ['p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'span'] },
+      { key: 'fontSize', label: 'フォントサイズ', type: 'text', placeholder: '16px' },
+      { key: 'fontWeight', label: '太さ', type: 'text', placeholder: '400' },
+      { key: 'color', label: '文字色', type: 'color' },
+      { key: 'lineHeight', label: '行間', type: 'text', placeholder: '1.5' },
+      { key: 'margin', label: 'マージン', type: 'text', placeholder: '0 0 16px' },
+      { key: 'textAlign', label: 'テキスト揃え', type: 'select', options: ['', 'left', 'center', 'right', 'justify'] }
+    ],
+    allowChildren: []
+  },
+  image: {
+    label: '画像',
+    description: 'DriveImageギャラリーと連携可能なプレースホルダ。',
+    defaultProps: {
+      src: '',
+      alt: '',
+      width: '100%',
+      height: 'auto',
+      objectFit: 'cover',
+      borderRadius: '12px',
+      aspectRatio: '16/9',
+      bindingKey: 'image'
+    },
+    properties: [
+      { key: 'bindingKey', label: '画像差替キー', type: 'text', placeholder: 'image' },
+      { key: 'src', label: '初期画像URL', type: 'text', placeholder: 'https://...' },
+      { key: 'alt', label: '代替テキスト', type: 'text', placeholder: '説明文' },
+      { key: 'width', label: '幅', type: 'text', placeholder: '100%' },
+      { key: 'height', label: '高さ', type: 'text', placeholder: 'auto' },
+      { key: 'aspectRatio', label: 'アスペクト比', type: 'text', placeholder: '16/9' },
+      { key: 'objectFit', label: 'object-fit', type: 'select', options: ['cover', 'contain', 'fill', 'none', 'scale-down'] },
+      { key: 'borderRadius', label: '角丸', type: 'text', placeholder: '12px' }
+    ],
+    allowChildren: []
+  },
+  button: {
+    label: 'ボタン',
+    description: 'CTAボタン。リンク付きテキスト。',
+    defaultProps: {
+      content: 'Button',
+      href: '#',
+      bindingKey: 'buttonLabel',
+      justify: 'center',
+      padding: '12px 20px',
+      background: '#2563eb',
+      color: '#ffffff',
+      borderRadius: '8px'
+    },
+    properties: [
+      { key: 'content', label: 'ボタン文言', type: 'text', placeholder: '詳細を見る' },
+      { key: 'bindingKey', label: 'テキスト差替キー', type: 'text', placeholder: 'buttonLabel' },
+      { key: 'href', label: 'リンクURL', type: 'text', placeholder: 'https://example.com' },
+      { key: 'background', label: '背景色', type: 'color' },
+      { key: 'color', label: '文字色', type: 'color' },
+      { key: 'padding', label: 'パディング', type: 'text', placeholder: '12px 20px' },
+      { key: 'borderRadius', label: '角丸', type: 'text', placeholder: '8px' },
+      { key: 'textAlign', label: '揃え', type: 'select', options: ['', 'left', 'center', 'right'] }
+    ],
+    allowChildren: []
+  },
+  divider: {
+    label: '区切り線',
+    description: '水平線または余白。',
+    defaultProps: {
+      height: '1px',
+      background: 'rgba(148, 163, 184, 0.3)',
+      margin: '24px 0'
+    },
+    properties: [
+      { key: 'height', label: '太さ', type: 'text', placeholder: '1px' },
+      { key: 'background', label: '色', type: 'color' },
+      { key: 'margin', label: '余白', type: 'text', placeholder: '24px 0' }
+    ],
+    allowChildren: []
+  }
+};
+
+const RESPONSIVE_MEDIA = {
+  desktop: '@media (min-width: 1025px)',
+  tablet: '@media (max-width: 1024px) and (min-width: 641px)',
+  mobile: '@media (max-width: 640px)'
+};
+
+const TEMPLATE_STORAGE_KEY = 'wiki-template-builder-draft';
+
+function randomId(prefix = 'tpl') {
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function camelToKebab(str) {
+  return str.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+}
+
+function mergeStyles(base, overrides = {}) {
+  const result = { ...base };
+  Object.keys(overrides || {}).forEach((key) => {
+    const value = overrides[key];
+    if (value === undefined || value === null || value === '') {
+      delete result[key];
+    } else {
+      result[key] = value;
+    }
+  });
+  return result;
+}
+
+function walkNodes(nodes = [], callback) {
+  nodes.forEach((node) => {
+    callback(node);
+    if (Array.isArray(node.children) && node.children.length) {
+      walkNodes(node.children, callback);
+    }
+  });
+}
+
+function findNode(nodes, id) {
+  let found = null;
+  walkNodes(nodes, (node) => {
+    if (node.id === id) {
+      found = node;
+    }
+  });
+  return found;
+}
+
+function removeNode(nodes, id) {
+  for (let i = nodes.length - 1; i >= 0; i -= 1) {
+    const node = nodes[i];
+    if (node.id === id) {
+      nodes.splice(i, 1);
+      return true;
+    }
+    if (node.children && node.children.length) {
+      const removed = removeNode(node.children, id);
+      if (removed) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function createNode(type) {
+  const def = NODE_DEFINITIONS[type];
+  if (!def) {
+    throw new Error('Unknown node type: ' + type);
+  }
+  return {
+    id: randomId('node'),
+    type,
+    props: clone(def.defaultProps || {}),
+    responsive: {
+      desktop: {},
+      tablet: {},
+      mobile: {}
+    },
+    children: def.allowChildren && def.allowChildren.length ? [] : undefined
+  };
+}
+
+function ensureResponsiveObject(node) {
+  node.responsive = node.responsive || {};
+  BREAKPOINTS.filter((bp) => bp !== 'base').forEach((bp) => {
+    node.responsive[bp] = node.responsive[bp] || {};
+  });
+  return node;
+}
+
+function styleObjectToString(style = {}) {
+  return Object.entries(style)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${camelToKebab(key)}: ${value}`)
+    .join('; ');
+}
+
+function renderNodeToHTML(node, templateId) {
+  const baseStyles = mergeStyles(node.props || {}, {});
+  const className = `${templateId}-${node.id}`;
+  const nodeAttrs = [`class="${className}"`, `style="${styleObjectToString(baseStyles)}"`, `data-template-node="${node.type}"`, `data-template-node-id="${node.id}"`];
+  let innerHTML = '';
+  const bindingKey = node.props?.bindingKey || '';
+  if (node.type === 'group') {
+    const childrenHTML = (node.children || []).map((child) => renderNodeToHTML(child, templateId)).join('');
+    innerHTML = childrenHTML;
+  } else if (node.type === 'text') {
+    const tag = node.props?.tag || 'p';
+    const attrs = [...nodeAttrs];
+    attrs.push(`data-template-binding="${bindingKey || ''}"`);
+    const content = node.props?.content || '';
+    return `<${tag} ${attrs.join(' ')}>${content}</${tag}>`;
+  } else if (node.type === 'image') {
+    const attrs = [...nodeAttrs];
+    attrs.push(`data-template-binding="${bindingKey || ''}"`);
+    const imgAttrs = [`alt="${node.props?.alt || ''}"`];
+    if (node.props?.src) {
+      imgAttrs.push(`src="${node.props.src}"`);
+    } else {
+      imgAttrs.push('src=""');
+    }
+    if (node.props?.width) {
+      imgAttrs.push(`width="${node.props.width}"`);
+    }
+    if (node.props?.height && node.props.height !== 'auto') {
+      imgAttrs.push(`height="${node.props.height}"`);
+    }
+    return `<figure ${attrs.join(' ')}><img ${imgAttrs.join(' ')} /></figure>`;
+  } else if (node.type === 'button') {
+    const attrs = [...nodeAttrs];
+    attrs.push(`data-template-binding="${bindingKey || ''}"`);
+    const href = node.props?.href || '#';
+    const content = node.props?.content || 'Button';
+    return `<div ${attrs.join(' ')}><a href="${href}" class="${className}__link">${content}</a></div>`;
+  } else if (node.type === 'divider') {
+    return `<div ${nodeAttrs.join(' ')}></div>`;
+  }
+
+  const attrs = [...nodeAttrs];
+  if (bindingKey) {
+    attrs.push(`data-template-binding="${bindingKey}"`);
+  }
+  return `<div ${attrs.join(' ')}>${innerHTML}</div>`;
+}
+
+function collectResponsiveRules(templateId, nodes) {
+  const rules = [];
+  walkNodes(nodes || [], (node) => {
+    if (!node.responsive) {
+      return;
+    }
+    Object.entries(node.responsive).forEach(([breakpoint, overrides]) => {
+      if (!overrides || !Object.keys(overrides).length) {
+        return;
+      }
+      const media = RESPONSIVE_MEDIA[breakpoint];
+      if (!media) {
+        return;
+      }
+      const className = `${templateId}-${node.id}`;
+      rules.push(`${media} { .${className} { ${styleObjectToString(overrides)} } }`);
+    });
+  });
+  return rules;
+}
+
+function generateTemplateHTML(template, options = {}) {
+  const templateId = template.id || randomId('template');
+  const childrenHTML = (template.children || []).map((node) => renderNodeToHTML(node, templateId)).join('');
+  const responsiveCss = collectResponsiveRules(templateId, template.children || []);
+  const styleId = `template-style-${templateId}`;
+  let styleTag = '';
+  if (responsiveCss.length && options.includeStyleTag !== false) {
+    styleTag = `<style id="${styleId}">${responsiveCss.join('\n')}</style>`;
+  }
+  return `${styleTag}<section class="wiki-template" data-template-id="${templateId}" data-template-instance="${randomId('instance')}">${childrenHTML}</section>`;
+}
+
+function createEmptyTemplate() {
+  return {
+    id: randomId('template'),
+    name: '新規テンプレート',
+    category: 'layout',
+    version: '1.0.0',
+    description: '',
+    thumbnail: '',
+    author: '',
+    children: [
+      {
+        ...createNode('group'),
+        props: {
+          ...NODE_DEFINITIONS.group.defaultProps,
+          padding: '32px',
+          gap: '24px',
+          background: '#ffffff',
+          borderRadius: '16px'
+        }
+      }
+    ]
+  };
+}
+
+class TemplateBuilderUI {
+  constructor(options) {
+    this.editor = options.editor;
+    this.store = options.store;
+    this.extension = options.extension;
+    this.modalId = options.modalId || 'template-builder-modal';
+    this.activeBreakpoint = 'base';
+    this.templates = [];
+    this.state = {
+      template: createEmptyTemplate(),
+      selectedNodeId: null,
+      isSaving: false,
+    };
+    this.createModal();
+    this.restoreDraft();
+    if (this.store) {
+      this.loadTemplates();
+    }
+  }
+
+  createModal() {
+    this.overlay = document.createElement('div');
+    this.overlay.className = 'template-builder-overlay';
+    this.overlay.dataset.visible = 'false';
+    this.overlay.innerHTML = `
+      <div class="template-builder-dialog" role="dialog" aria-modal="true" aria-labelledby="template-builder-title">
+        <header class="template-builder-header">
+          <div>
+            <h2 id="template-builder-title">UIテンプレートビルダー</h2>
+            <p class="template-builder-sub">要素の追加・レスポンシブ設定・保存を行えます。</p>
+          </div>
+          <div class="template-builder-header-actions">
+            <button class="template-builder-close" type="button" aria-label="閉じる">×</button>
+          </div>
+        </header>
+        <div class="template-builder-body">
+          <aside class="template-builder-sidebar">
+            <div class="template-list-toolbar">
+              <button class="tb-refresh" type="button">再読込</button>
+              <button class="tb-new" type="button">新規作成</button>
+            </div>
+            <div class="template-list" data-role="template-list"></div>
+          </aside>
+          <div class="template-builder-main">
+            <div class="template-meta">
+              <div class="template-meta-field">
+                <label>テンプレート名</label>
+                <input type="text" data-role="template-name" placeholder="Two Column Card" />
+              </div>
+              <div class="template-meta-field">
+                <label>カテゴリ</label>
+                <input type="text" data-role="template-category" placeholder="card / hero / banner" />
+              </div>
+              <div class="template-meta-field">
+                <label>説明</label>
+                <input type="text" data-role="template-description" placeholder="用途をメモ" />
+              </div>
+              <div class="template-meta-field">
+                <label>ブレークポイント</label>
+                <div class="breakpoint-toggle" data-role="breakpoints"></div>
+              </div>
+            </div>
+            <div class="template-workspace">
+              <div class="template-canvas" data-role="canvas"></div>
+              <div class="template-properties">
+                <div class="properties-header">
+                  <h3>プロパティ</h3>
+                  <div class="properties-node-info" data-role="selected-node"></div>
+                </div>
+                <div class="properties-content" data-role="properties"></div>
+                <div class="properties-actions">
+                  <button type="button" data-role="delete-node" class="danger">要素を削除</button>
+                </div>
+              </div>
+            </div>
+            <div class="template-preview">
+              <div class="preview-toolbar">
+                <span>プレビュー</span>
+                <div class="preview-breakpoints">
+                  <button type="button" data-preview="desktop" class="active">PC</button>
+                  <button type="button" data-preview="tablet">Tablet</button>
+                  <button type="button" data-preview="mobile">Mobile</button>
+                </div>
+                <button type="button" data-role="insert" class="primary">エディタに挿入</button>
+                <button type="button" data-role="save" class="primary">保存</button>
+              </div>
+              <div class="preview-viewport" data-role="preview"></div>
+            </div>
+          </div>
+        </div>
+      </div>`;
+    document.body.appendChild(this.overlay);
+
+    this.overlay.querySelector('.template-builder-close').addEventListener('click', () => this.close());
+    this.overlay.addEventListener('click', (event) => {
+      if (event.target === this.overlay) {
+        this.close();
+      }
+    });
+
+    this.canvasElement = this.overlay.querySelector('[data-role="canvas"]');
+    this.propertiesElement = this.overlay.querySelector('[data-role="properties"]');
+    this.selectedNodeLabel = this.overlay.querySelector('[data-role="selected-node"]');
+    this.previewElement = this.overlay.querySelector('[data-role="preview"]');
+    this.templateListElement = this.overlay.querySelector('[data-role="template-list"]');
+    this.templateNameInput = this.overlay.querySelector('[data-role="template-name"]');
+    this.templateCategoryInput = this.overlay.querySelector('[data-role="template-category"]');
+    this.templateDescriptionInput = this.overlay.querySelector('[data-role="template-description"]');
+    this.deleteNodeButton = this.overlay.querySelector('[data-role="delete-node"]');
+    this.breakpointToggle = this.overlay.querySelector('[data-role="breakpoints"]');
+    this.saveButton = this.overlay.querySelector('[data-role="save"]');
+    this.insertButton = this.overlay.querySelector('[data-role="insert"]');
+
+    this.templateNameInput.addEventListener('input', () => this.updateTemplateMeta());
+    this.templateCategoryInput.addEventListener('input', () => this.updateTemplateMeta());
+    this.templateDescriptionInput.addEventListener('input', () => this.updateTemplateMeta());
+    this.deleteNodeButton.addEventListener('click', () => this.deleteSelectedNode());
+    this.saveButton.addEventListener('click', () => this.handleSave());
+    this.insertButton.addEventListener('click', () => this.handleInsert());
+
+    this.overlay.querySelector('.tb-refresh').addEventListener('click', () => this.loadTemplates(true));
+    this.overlay.querySelector('.tb-new').addEventListener('click', () => this.createNewTemplate());
+
+    this.overlay.querySelectorAll('.preview-breakpoints button').forEach((button) => {
+      button.addEventListener('click', () => {
+        this.overlay.querySelectorAll('.preview-breakpoints button').forEach((btn) => btn.classList.remove('active'));
+        button.classList.add('active');
+        this.renderPreview(button.dataset.preview);
+      });
+    });
+
+    this.renderBreakpointToggle();
+  }
+
+  open() {
+    this.overlay.dataset.visible = 'true';
+    this.render();
+    this.renderPreview('desktop');
+  }
+
+  close() {
+    this.overlay.dataset.visible = 'false';
+    this.saveDraft();
+  }
+
+  createNewTemplate() {
+    this.state.template = createEmptyTemplate();
+    this.state.selectedNodeId = this.state.template.children[0].id;
+    this.render();
+    this.renderPreview('desktop');
+  }
+
+  async loadTemplates(forceRefresh = false) {
+    if (!this.store) {
+      return;
+    }
+    try {
+      this.templates = await this.store.fetchTemplates({ forceRefresh });
+      this.renderTemplateList();
+    } catch (error) {
+      console.error('[TemplateBuilder] Failed to load templates', error);
+    }
+  }
+
+  async saveDraft() {
+    try {
+      const payload = {
+        template: this.state.template,
+        selectedNodeId: this.state.selectedNodeId,
+        activeBreakpoint: this.activeBreakpoint,
+        timestamp: Date.now(),
+      };
+      localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.warn('[TemplateBuilder] Failed to save draft', error);
+    }
+  }
+
+  restoreDraft() {
+    try {
+      const raw = localStorage.getItem(TEMPLATE_STORAGE_KEY);
+      if (!raw) {
+        this.state.selectedNodeId = this.state.template.children[0].id;
+        return;
+      }
+      const payload = JSON.parse(raw);
+      if (payload && payload.template) {
+        this.state.template = payload.template;
+        walkNodes(this.state.template.children || [], ensureResponsiveObject);
+        this.state.selectedNodeId = payload.selectedNodeId || (payload.template.children?.[0]?.id ?? null);
+        this.activeBreakpoint = payload.activeBreakpoint || 'base';
+      }
+    } catch (error) {
+      console.warn('[TemplateBuilder] Failed to restore draft', error);
+    }
+  }
+
+  renderTemplateList() {
+    if (!this.templateListElement) {
+      return;
+    }
+    this.templateListElement.innerHTML = '';
+    if (!this.templates.length) {
+      this.templateListElement.innerHTML = '<p class="template-list-empty">テンプレートがありません。</p>';
+      return;
+    }
+    this.templates.forEach((tpl) => {
+      const item = document.createElement('button');
+      item.className = 'template-list-item';
+      item.type = 'button';
+      item.innerHTML = `
+        <span class="template-list-title">${tpl.name || '無題テンプレート'}</span>
+        <span class="template-list-meta">${tpl.category || ''}</span>`;
+      item.addEventListener('click', async () => {
+        await this.loadTemplate(tpl.id);
+      });
+      this.templateListElement.appendChild(item);
+    });
+  }
+
+  async loadTemplate(id) {
+    if (!this.store || !id) {
+      return;
+    }
+    try {
+      const result = await this.store.fetchTemplate(id);
+      if (!result) {
+        return;
+      }
+      let json;
+      try {
+        json = typeof result.json === 'string' ? JSON.parse(result.json) : result.json;
+      } catch (error) {
+        console.error('[TemplateBuilder] Failed to parse template json', error);
+        return;
+      }
+      this.state.template = {
+        id: result.id || json.id || randomId('template'),
+        name: result.name || json.name || '無題テンプレート',
+        category: result.category || json.category || '',
+        description: json.description || '',
+        version: result.version || json.version || '1.0.0',
+        thumbnail: result.thumbnail || json.thumbnail || '',
+        author: result.author || json.author || '',
+        children: json.children || []
+      };
+      if (!this.state.template.children.length) {
+        this.state.template.children = [createNode('group')];
+      }
+      walkNodes(this.state.template.children, ensureResponsiveObject);
+      this.state.selectedNodeId = this.state.template.children[0].id;
+      this.render();
+      this.renderPreview('desktop');
+    } catch (error) {
+      console.error('[TemplateBuilder] Failed to load template', error);
+    }
+  }
+
+  updateTemplateMeta() {
+    this.state.template.name = this.templateNameInput.value;
+    this.state.template.category = this.templateCategoryInput.value;
+    this.state.template.description = this.templateDescriptionInput.value;
+    this.renderPreview();
+  }
+
+  render() {
+    const template = this.state.template;
+    this.templateNameInput.value = template.name || '';
+    this.templateCategoryInput.value = template.category || '';
+    this.templateDescriptionInput.value = template.description || '';
+    this.renderCanvas();
+    this.renderProperties();
+    this.renderPreview();
+    this.renderTemplateList();
+    this.renderBreakpointToggle();
+  }
+
+  renderCanvas() {
+    if (!this.canvasElement) {
+      return;
+    }
+    this.canvasElement.innerHTML = '';
+    const rootList = document.createElement('div');
+    rootList.className = 'canvas-node-list';
+    (this.state.template.children || []).forEach((node) => {
+      rootList.appendChild(this.renderCanvasNode(node, null));
+    });
+    this.canvasElement.appendChild(rootList);
+    const addButtons = this.createAddButtons(null);
+    addButtons.classList.add('canvas-add-root');
+    this.canvasElement.appendChild(addButtons);
+  }
+
+  renderCanvasNode(node, parentId) {
+    const container = document.createElement('div');
+    container.className = 'canvas-node';
+    if (node.id === this.state.selectedNodeId) {
+      container.classList.add('selected');
+    }
+    container.dataset.nodeId = node.id;
+    const header = document.createElement('div');
+    header.className = 'canvas-node-header';
+    const title = document.createElement('div');
+    title.className = 'canvas-node-title';
+    const def = NODE_DEFINITIONS[node.type];
+    title.textContent = def ? def.label : node.type;
+    header.appendChild(title);
+    const actions = document.createElement('div');
+    actions.className = 'canvas-node-actions';
+    const selectBtn = document.createElement('button');
+    selectBtn.type = 'button';
+    selectBtn.textContent = '選択';
+    selectBtn.addEventListener('click', () => {
+      this.state.selectedNodeId = node.id;
+      this.render();
+    });
+    actions.appendChild(selectBtn);
+    if (def && def.allowChildren && def.allowChildren.length) {
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.textContent = '子を追加';
+      addBtn.addEventListener('click', () => {
+        this.showAddMenu(node.id, addBtn);
+      });
+      actions.appendChild(addBtn);
+    }
+    if (parentId) {
+      const upBtn = document.createElement('button');
+      upBtn.type = 'button';
+      upBtn.textContent = '↑';
+      upBtn.addEventListener('click', () => this.moveNode(node.id, parentId, -1));
+      const downBtn = document.createElement('button');
+      downBtn.type = 'button';
+      downBtn.textContent = '↓';
+      downBtn.addEventListener('click', () => this.moveNode(node.id, parentId, 1));
+      actions.appendChild(upBtn);
+      actions.appendChild(downBtn);
+    }
+    header.appendChild(actions);
+    container.appendChild(header);
+
+    if (node.children && node.children.length) {
+      const childrenContainer = document.createElement('div');
+      childrenContainer.className = 'canvas-node-children';
+      node.children.forEach((child) => {
+        childrenContainer.appendChild(this.renderCanvasNode(child, node.id));
+      });
+      const addButtons = this.createAddButtons(node.id);
+      childrenContainer.appendChild(addButtons);
+      container.appendChild(childrenContainer);
+    } else if (node.children) {
+      const addButtons = this.createAddButtons(node.id);
+      addButtons.classList.add('canvas-add-empty');
+      container.appendChild(addButtons);
+    }
+    return container;
+  }
+
+  createAddButtons(parentId) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'canvas-add-buttons';
+    const allowedTypes = this.getAllowedChildTypes(parentId);
+    if (!allowedTypes.length) {
+      const empty = document.createElement('p');
+      empty.className = 'canvas-add-none';
+      empty.textContent = '追加できる要素はありません';
+      wrapper.appendChild(empty);
+      return wrapper;
+    }
+    allowedTypes.forEach((type) => {
+      const def = NODE_DEFINITIONS[type];
+      if (!def) {
+        return;
+      }
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = `${def.label}を追加`;
+      button.addEventListener('click', () => {
+        this.addNode(parentId, type);
+      });
+      wrapper.appendChild(button);
+    });
+    return wrapper;
+  }
+
+  getAllowedChildTypes(parentId) {
+    if (!parentId) {
+      return ['group'];
+    }
+    const parentNode = findNode(this.state.template.children, parentId);
+    if (!parentNode) {
+      return [];
+    }
+    const parentDef = NODE_DEFINITIONS[parentNode.type];
+    if (parentDef && Array.isArray(parentDef.allowChildren) && parentDef.allowChildren.length) {
+      return parentDef.allowChildren;
+    }
+    return [];
+  }
+
+  showAddMenu(parentId, anchor) {
+    const menu = document.createElement('div');
+    menu.className = 'canvas-add-menu';
+    const allowedTypes = this.getAllowedChildTypes(parentId);
+    if (!allowedTypes.length) {
+      const empty = document.createElement('p');
+      empty.className = 'canvas-add-none';
+      empty.textContent = '追加できる要素はありません';
+      menu.appendChild(empty);
+    } else {
+      allowedTypes.forEach((type) => {
+        const def = NODE_DEFINITIONS[type];
+        if (!def) {
+          return;
+        }
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = def.label;
+        button.addEventListener('click', () => {
+          this.addNode(parentId, type);
+          menu.remove();
+        });
+        menu.appendChild(button);
+      });
+    }
+    document.body.appendChild(menu);
+    const rect = anchor.getBoundingClientRect();
+    menu.style.left = `${rect.left + window.scrollX}px`;
+    menu.style.top = `${rect.bottom + window.scrollY + 4}px`;
+    const remove = () => {
+      menu.remove();
+      document.removeEventListener('click', outsideHandler, true);
+    };
+    const outsideHandler = (event) => {
+      if (!menu.contains(event.target)) {
+        remove();
+      }
+    };
+    document.addEventListener('click', outsideHandler, true);
+  }
+
+  addNode(parentId, type) {
+    const newNode = createNode(type);
+    ensureResponsiveObject(newNode);
+    if (!parentId) {
+      this.state.template.children = this.state.template.children || [];
+      this.state.template.children.push(newNode);
+    } else {
+      const parentNode = findNode(this.state.template.children, parentId);
+      if (!parentNode) {
+        return;
+      }
+      parentNode.children = parentNode.children || [];
+      parentNode.children.push(newNode);
+    }
+    this.state.selectedNodeId = newNode.id;
+    this.render();
+  }
+
+  moveNode(nodeId, parentId, direction) {
+    const parentNode = parentId ? findNode(this.state.template.children, parentId) : { children: this.state.template.children };
+    if (!parentNode || !Array.isArray(parentNode.children)) {
+      return;
+    }
+    const index = parentNode.children.findIndex((child) => child.id === nodeId);
+    if (index === -1) {
+      return;
+    }
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= parentNode.children.length) {
+      return;
+    }
+    const [node] = parentNode.children.splice(index, 1);
+    parentNode.children.splice(newIndex, 0, node);
+    this.render();
+  }
+
+  deleteSelectedNode() {
+    const nodeId = this.state.selectedNodeId;
+    if (!nodeId) {
+      return;
+    }
+    if (this.state.template.children.length <= 1) {
+      alert('最低1つのルート要素が必要です。');
+      return;
+    }
+    removeNode(this.state.template.children, nodeId);
+    this.state.selectedNodeId = this.state.template.children[0]?.id || null;
+    this.render();
+  }
+
+  renderProperties() {
+    if (!this.propertiesElement) {
+      return;
+    }
+    const node = findNode(this.state.template.children, this.state.selectedNodeId);
+    if (!node) {
+      this.propertiesElement.innerHTML = '<p class="properties-empty">要素を選択してください。</p>';
+      this.selectedNodeLabel.textContent = '';
+      return;
+    }
+    ensureResponsiveObject(node);
+    const def = NODE_DEFINITIONS[node.type];
+    this.selectedNodeLabel.textContent = `${def?.label || node.type} / ${node.id}`;
+    const activeTarget = this.activeBreakpoint === 'base' ? node.props : node.responsive[this.activeBreakpoint];
+    this.propertiesElement.innerHTML = '';
+
+    const form = document.createElement('div');
+    form.className = 'properties-form';
+    (def?.properties || []).forEach((property) => {
+      const field = document.createElement('label');
+      field.className = 'property-field';
+      const title = document.createElement('span');
+      title.textContent = property.label;
+      field.appendChild(title);
+      let input;
+      const currentValue = this.getPropertyValue(node, property.key);
+      if (property.type === 'select') {
+        input = document.createElement('select');
+        (property.options || ['']).forEach((option) => {
+          const opt = document.createElement('option');
+          opt.value = option;
+          opt.textContent = option || '（指定なし）';
+          if (currentValue === option) {
+            opt.selected = true;
+          }
+          input.appendChild(opt);
+        });
+      } else if (property.type === 'textarea') {
+        input = document.createElement('textarea');
+        input.value = currentValue || '';
+      } else if (property.type === 'color') {
+        input = document.createElement('input');
+        input.type = 'color';
+        input.value = currentValue || '#000000';
+      } else {
+        input = document.createElement('input');
+        input.type = 'text';
+        input.value = currentValue || '';
+        if (property.placeholder) {
+          input.placeholder = property.placeholder;
+        }
+      }
+      input.addEventListener('input', () => {
+        this.setPropertyValue(node, property.key, input.value);
+      });
+      field.appendChild(input);
+      form.appendChild(field);
+    });
+
+    const commonProps = ['width', 'height', 'margin', 'padding', 'background'];
+    commonProps.forEach((key) => {
+      if (def?.properties?.some((prop) => prop.key === key)) {
+        return;
+      }
+      const field = document.createElement('label');
+      field.className = 'property-field';
+      field.innerHTML = `<span>${key}</span>`;
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = this.getPropertyValue(node, key) || '';
+      input.addEventListener('input', () => {
+        this.setPropertyValue(node, key, input.value);
+      });
+      field.appendChild(input);
+      form.appendChild(field);
+    });
+
+    this.propertiesElement.appendChild(form);
+  }
+
+  getPropertyValue(node, key) {
+    if (!node) {
+      return '';
+    }
+    if (this.activeBreakpoint !== 'base') {
+      const overrides = node.responsive?.[this.activeBreakpoint];
+      if (overrides && overrides[key] !== undefined) {
+        return overrides[key];
+      }
+    }
+    return node.props?.[key] ?? '';
+  }
+
+  setPropertyValue(node, key, value) {
+    ensureResponsiveObject(node);
+    const normalized = typeof value === 'string' ? value.trim() : value ?? '';
+    const finalValue = normalized;
+    if (this.activeBreakpoint === 'base') {
+      if (!node.props) {
+        node.props = {};
+      }
+      if (finalValue === '') {
+        delete node.props[key];
+      } else {
+        node.props[key] = finalValue;
+      }
+    } else {
+      if (finalValue === '') {
+        delete node.responsive[this.activeBreakpoint][key];
+      } else {
+        node.responsive[this.activeBreakpoint][key] = finalValue;
+      }
+    }
+    this.renderPreview();
+  }
+
+  renderBreakpointToggle() {
+    if (!this.breakpointToggle) {
+      return;
+    }
+    this.breakpointToggle.innerHTML = '';
+    BREAKPOINTS.forEach((bp) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = BREAKPOINT_LABELS[bp] || bp;
+      if (this.activeBreakpoint === bp) {
+        button.classList.add('active');
+      }
+      button.addEventListener('click', () => {
+        this.activeBreakpoint = bp;
+        this.renderProperties();
+        this.renderBreakpointToggle();
+      });
+      this.breakpointToggle.appendChild(button);
+    });
+  }
+
+  renderPreview(mode = 'desktop') {
+    if (!this.previewElement) {
+      return;
+    }
+    const template = this.state.template;
+    this.previewElement.innerHTML = '';
+    const wrapper = document.createElement('div');
+    wrapper.className = `preview-wrapper preview-${mode}`;
+    const html = generateTemplateHTML(template);
+    wrapper.innerHTML = html;
+    this.previewElement.appendChild(wrapper);
+  }
+
+  injectResponsiveStyles() {
+    const templateId = this.state.template.id;
+    if (!templateId) {
+      return;
+    }
+    const cssRules = collectResponsiveRules(templateId, this.state.template.children || []);
+    if (!cssRules.length) {
+      return;
+    }
+    const styleId = `template-style-${templateId}`;
+    let styleElement = document.getElementById(styleId);
+    if (!styleElement) {
+      styleElement = document.createElement('style');
+      styleElement.id = styleId;
+      document.head.appendChild(styleElement);
+    }
+    styleElement.textContent = cssRules.join('\n');
+  }
+
+  async handleSave() {
+    if (!this.store) {
+      alert('バックエンドが設定されていません。');
+      return;
+    }
+    try {
+      this.saveButton.disabled = true;
+      const templateId = this.state.template.id || randomId('template');
+      this.state.template.id = templateId;
+      const payload = {
+        id: templateId,
+        name: this.state.template.name,
+        category: this.state.template.category,
+        version: this.state.template.version || '1.0.0',
+        thumbnail: this.state.template.thumbnail || '',
+        author: this.state.template.author || '',
+        json: {
+          id: templateId,
+          name: this.state.template.name,
+          category: this.state.template.category,
+          version: this.state.template.version,
+          description: this.state.template.description,
+          author: this.state.template.author,
+          thumbnail: this.state.template.thumbnail,
+          children: this.state.template.children,
+        },
+      };
+      await this.store.saveTemplate(payload);
+      await this.loadTemplates(true);
+      alert('テンプレートを保存しました。');
+    } catch (error) {
+      console.error('[TemplateBuilder] Failed to save template', error);
+      alert('テンプレートの保存に失敗しました: ' + error.message);
+    } finally {
+      this.saveButton.disabled = false;
+    }
+  }
+
+  handleInsert() {
+    const templateId = this.state.template.id || randomId('template');
+    this.state.template.id = templateId;
+    this.injectResponsiveStyles();
+    const html = generateTemplateHTML(this.state.template, { includeStyleTag: false });
+    this.editor.commands.insertContent(html);
+    this.close();
+  }
+}
+
+export const TemplateBuilderExtension = Extension.create({
+  name: 'templateBuilder',
+
+  addOptions() {
+    return {
+      toolbarSelector: '.toolbar',
+      buttonClass: 'toolbar-button',
+      buttonLabel: 'テンプレート',
+      store: null,
+      modalId: 'template-builder-modal',
+    };
+  },
+
+  onCreate() {
+    this.ensureBuilder();
+    this.addToolbarButton();
+  },
+
+  ensureBuilder() {
+    if (!this.builder) {
+      this.builder = new TemplateBuilderUI({
+        editor: this.editor,
+        store: this.options.store,
+        extension: this,
+        modalId: this.options.modalId,
+      });
+    }
+  },
+
+  addToolbarButton() {
+    const toolbar = document.querySelector(this.options.toolbarSelector);
+    if (!toolbar) {
+      console.warn('[TemplateBuilderExtension] Toolbar not found:', this.options.toolbarSelector);
+      return;
+    }
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = this.options.buttonClass;
+    button.textContent = this.options.buttonLabel;
+    button.addEventListener('click', () => this.editor.commands.openTemplateBuilder());
+    toolbar.appendChild(button);
+    this.toolbarButton = button;
+  },
+
+  addCommands() {
+    return {
+      openTemplateBuilder: () => () => {
+        this.ensureBuilder();
+        this.builder.open();
+        return true;
+      },
+      insertTemplate: (template) => ({ editor }) => {
+        if (!template) {
+          return false;
+        }
+        const templateId = template.id || randomId('template');
+        template.id = templateId;
+        const cssRules = collectResponsiveRules(templateId, template.children || []);
+        if (cssRules.length) {
+          const styleId = `template-style-${templateId}`;
+          let styleElement = document.getElementById(styleId);
+          if (!styleElement) {
+            styleElement = document.createElement('style');
+            styleElement.id = styleId;
+            document.head.appendChild(styleElement);
+          }
+          styleElement.textContent = cssRules.join('\n');
+        }
+        const html = generateTemplateHTML(template, { includeStyleTag: false });
+        editor.commands.insertContent(html);
+        return true;
+      },
+    };
+  },
+
+  onDestroy() {
+    if (this.toolbarButton) {
+      this.toolbarButton.remove();
+    }
+  },
+});

--- a/scripts/templateStore.js
+++ b/scripts/templateStore.js
@@ -1,0 +1,99 @@
+export class TemplateStore {
+    constructor(options = {}) {
+        this.endpoint = options.endpoint || window.TEMPLATE_BACKEND_URL || '';
+        this.fetchImpl = options.fetch || window.fetch.bind(window);
+        this.cache = {
+            templates: null,
+            fetchedAt: 0,
+        };
+        this.defaultTimeout = options.timeout || 15000;
+    }
+
+    async fetchTemplates({ forceRefresh = false } = {}) {
+        if (!forceRefresh && this.cache.templates && Date.now() - this.cache.fetchedAt < 60_000) {
+            return this.cache.templates;
+        }
+        const payload = { action: 'getTemplates' };
+        const response = await this._post(payload);
+        if (!response.success) {
+            throw new Error(response.message || 'Failed to fetch templates');
+        }
+        const templates = Array.isArray(response.templates) ? response.templates : [];
+        this.cache = {
+            templates,
+            fetchedAt: Date.now(),
+        };
+        return templates;
+    }
+
+    async fetchTemplate(id) {
+        if (!id) {
+            throw new Error('Template ID is required');
+        }
+        const payload = { action: 'getTemplate', id };
+        const response = await this._post(payload);
+        if (!response.success) {
+            throw new Error(response.message || 'Failed to fetch template');
+        }
+        return response.template || null;
+    }
+
+    async saveTemplate(template) {
+        if (!template || !template.id) {
+            throw new Error('Template payload must include id');
+        }
+        const payload = {
+            action: 'saveTemplate',
+            id: template.id,
+            name: template.name,
+            category: template.category || '',
+            json: typeof template.json === 'string' ? template.json : JSON.stringify(template.json || {}),
+            thumbnail: template.thumbnail || '',
+            author: template.author || '',
+            version: template.version || '',
+        };
+        const response = await this._post(payload);
+        if (!response.success) {
+            throw new Error(response.message || 'Failed to save template');
+        }
+        this.cache.fetchedAt = 0; // invalidate cache
+        return response;
+    }
+
+    async deleteTemplate(id) {
+        if (!id) {
+            throw new Error('Template ID is required');
+        }
+        const payload = { action: 'deleteTemplate', id };
+        const response = await this._post(payload);
+        if (!response.success) {
+            throw new Error(response.message || 'Failed to delete template');
+        }
+        this.cache.fetchedAt = 0;
+        return response;
+    }
+
+    async _post(body) {
+        if (!this.endpoint) {
+            throw new Error('Template backend endpoint is not configured');
+        }
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), this.defaultTimeout);
+        try {
+            const response = await this.fetchImpl(this.endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(body),
+                signal: controller.signal,
+            });
+            if (!response.ok) {
+                throw new Error('Request failed with status ' + response.status);
+            }
+            return await response.json();
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+}

--- a/template-backend.gs
+++ b/template-backend.gs
@@ -1,0 +1,291 @@
+/**
+ * Template management backend for TipTap UI template builder.
+ *
+ * This Apps Script Web App stores template definitions inside a Google Sheet.
+ * The implementation mirrors wiki-backend.gs but focuses on template data.
+ */
+const TEMPLATE_CONFIG = {
+  SHEET_ID: '1ZN1LQdk2TDNmtMOdx6mXBNe3jQjFfM6CXWYc2Z4vXDk',
+  SHEET_NAME: 'Wiki_Templates',
+  ALLOWED_ORIGINS: ['https://brahmoon.github.io'],
+};
+
+function doGet(e) {
+  const origin = getTemplateRequestOrigin(e);
+  const data = parseTemplateRequestData(e);
+
+  if (!data.action) {
+    return createTemplateJsonOutput({
+      success: true,
+      message: 'Template backend is running',
+      timestamp: new Date().toISOString(),
+    }, origin);
+  }
+
+  try {
+    const result = routeTemplateAction(data);
+    return createTemplateJsonOutput(result, origin);
+  } catch (error) {
+    return createTemplateJsonOutput({
+      success: false,
+      message: 'Internal server error: ' + error,
+    }, origin);
+  }
+}
+
+function doPost(e) {
+  const origin = getTemplateRequestOrigin(e);
+  try {
+    const data = parseTemplateRequestData(e);
+    const result = routeTemplateAction(data);
+    return createTemplateJsonOutput(result, origin);
+  } catch (error) {
+    return createTemplateJsonOutput({
+      success: false,
+      message: 'Internal server error: ' + error,
+    }, origin);
+  }
+}
+
+function createTemplateJsonOutput(data, requestOrigin) {
+  const output = ContentService
+    .createTextOutput(JSON.stringify(data))
+    .setMimeType(ContentService.MimeType.JSON);
+
+  const allowedOrigins = (TEMPLATE_CONFIG.ALLOWED_ORIGINS || []).map(function(origin) {
+    return (origin || '').trim();
+  }).filter(function(origin) {
+    return origin;
+  });
+
+  if (allowedOrigins.length) {
+    if (allowedOrigins.indexOf('*') !== -1) {
+      output.setHeader('Access-Control-Allow-Origin', '*');
+    } else if (requestOrigin && allowedOrigins.indexOf(requestOrigin) !== -1) {
+      output
+        .setHeader('Access-Control-Allow-Origin', requestOrigin)
+        .setHeader('Vary', 'Origin');
+    }
+  }
+
+  return output;
+}
+
+function getTemplateRequestOrigin(e) {
+  if (!e || !e.headers) {
+    return '';
+  }
+  return e.headers.origin || e.headers.Origin || '';
+}
+
+function parseTemplateRequestData(e) {
+  const data = {};
+
+  if (e && e.parameter) {
+    Object.keys(e.parameter).forEach(function(key) {
+      data[key] = e.parameter[key];
+    });
+  }
+
+  if (e && e.postData && e.postData.contents) {
+    try {
+      const parsed = JSON.parse(e.postData.contents);
+      Object.keys(parsed || {}).forEach(function(key) {
+        data[key] = parsed[key];
+      });
+    } catch (error) {
+      Logger.log('[TemplateBackend] Failed to parse request body: %s', error);
+      data.rawBody = e.postData.contents;
+    }
+  }
+
+  return data;
+}
+
+function routeTemplateAction(data) {
+  const action = (data.action || '').toString();
+
+  switch (action) {
+    case 'saveTemplate':
+      return saveTemplate({
+        id: data.id,
+        name: data.name,
+        category: data.category,
+        json: data.json,
+        thumbnail: data.thumbnail,
+        author: data.author,
+        version: data.version,
+      });
+    case 'getTemplates':
+      return getTemplates();
+    case 'getTemplate':
+      return getTemplateById(data.id);
+    case 'deleteTemplate':
+      return deleteTemplateById(data.id);
+    default:
+      return {
+        success: false,
+        message: 'Unknown action: ' + action,
+      };
+  }
+}
+
+function getTemplateSheet() {
+  const spreadsheet = SpreadsheetApp.openById(TEMPLATE_CONFIG.SHEET_ID);
+  const sheetName = TEMPLATE_CONFIG.SHEET_NAME || 'Wiki_Templates';
+  let sheet = spreadsheet.getSheetByName(sheetName);
+  if (!sheet) {
+    sheet = spreadsheet.insertSheet(sheetName);
+  }
+  ensureTemplateSheetStructure(sheet);
+  return sheet;
+}
+
+function ensureTemplateSheetStructure(sheet) {
+  const headers = ['ID', 'Name', 'Category', 'Json', 'Thumbnail', 'Author', 'UpdatedAt', 'Version'];
+  const headerRange = sheet.getRange(1, 1, 1, headers.length);
+  const current = headerRange.getValues()[0];
+  let needsUpdate = false;
+  for (var i = 0; i < headers.length; i++) {
+    if (current[i] !== headers[i]) {
+      needsUpdate = true;
+      break;
+    }
+  }
+  if (needsUpdate) {
+    headerRange.setValues([headers]);
+  }
+  if (sheet.getFrozenRows() < 1) {
+    sheet.setFrozenRows(1);
+  }
+}
+
+function getTemplates() {
+  try {
+    const sheet = getTemplateSheet();
+    const lastRow = sheet.getLastRow();
+    if (lastRow < 2) {
+      return { success: true, templates: [] };
+    }
+    const width = Math.max(sheet.getLastColumn(), 8);
+    const values = sheet.getRange(2, 1, lastRow - 1, width).getValues();
+    const templates = values.filter(function(row) {
+      return row[0];
+    }).map(function(row) {
+      return {
+        id: row[0],
+        name: row[1] || '無題テンプレート',
+        category: row[2] || '',
+        thumbnail: row[4] || '',
+        author: row[5] || '',
+        updatedAt: row[6] || '',
+        version: row[7] || '',
+      };
+    });
+    return { success: true, templates: templates };
+  } catch (error) {
+    return { success: false, message: 'Failed to get templates: ' + error };
+  }
+}
+
+function getTemplateById(id) {
+  if (!id) {
+    return { success: false, message: 'Template ID is required' };
+  }
+
+  try {
+    const sheet = getTemplateSheet();
+    const lastRow = sheet.getLastRow();
+    if (lastRow < 2) {
+      return { success: false, message: 'Template not found' };
+    }
+    const range = sheet.getRange(2, 1, lastRow - 1, 8);
+    const values = range.getValues();
+    for (var i = 0; i < values.length; i++) {
+      var row = values[i];
+      if (row[0] === id) {
+        return {
+          success: true,
+          template: {
+            id: row[0],
+            name: row[1] || '無題テンプレート',
+            category: row[2] || '',
+            json: row[3] || '',
+            thumbnail: row[4] || '',
+            author: row[5] || '',
+            updatedAt: row[6] || '',
+            version: row[7] || '',
+          },
+        };
+      }
+    }
+    return { success: false, message: 'Template not found: ' + id };
+  } catch (error) {
+    return { success: false, message: 'Failed to get template: ' + error };
+  }
+}
+
+function saveTemplate(template) {
+  if (!template || !template.id) {
+    return { success: false, message: 'Invalid template payload' };
+  }
+  const now = new Date().toISOString();
+  const sheet = getTemplateSheet();
+  const lastRow = sheet.getLastRow();
+  const width = Math.max(sheet.getLastColumn(), 8);
+  if (lastRow >= 2) {
+    const range = sheet.getRange(2, 1, lastRow - 1, width);
+    const values = range.getValues();
+    for (var i = 0; i < values.length; i++) {
+      if (values[i][0] === template.id) {
+        range.getCell(i + 1, 1).offset(0, 0, 1, width).setValues([[
+          template.id,
+          template.name || '無題テンプレート',
+          template.category || '',
+          template.json || '',
+          template.thumbnail || '',
+          template.author || '',
+          now,
+          template.version || '',
+        ]]);
+        return { success: true, updatedAt: now, id: template.id };
+      }
+    }
+  }
+  sheet.appendRow([
+    template.id,
+    template.name || '無題テンプレート',
+    template.category || '',
+    template.json || '',
+    template.thumbnail || '',
+    template.author || '',
+    now,
+    template.version || '',
+  ]);
+  return { success: true, createdAt: now, id: template.id };
+}
+
+function deleteTemplateById(id) {
+  if (!id) {
+    return { success: false, message: 'Template ID is required' };
+  }
+
+  try {
+    const sheet = getTemplateSheet();
+    const lastRow = sheet.getLastRow();
+    if (lastRow < 2) {
+      return { success: false, message: 'Template not found' };
+    }
+    const range = sheet.getRange(2, 1, lastRow - 1, 1);
+    const values = range.getValues();
+    for (var i = 0; i < values.length; i++) {
+      if (values[i][0] === id) {
+        sheet.deleteRow(i + 2);
+        return { success: true };
+      }
+    }
+    return { success: false, message: 'Template not found: ' + id };
+  } catch (error) {
+    return { success: false, message: 'Failed to delete template: ' + error };
+  }
+}

--- a/tiptap-image5.html
+++ b/tiptap-image5.html
@@ -1,0 +1,821 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TipTap UIテンプレートビルダー</title>
+  <link rel="stylesheet" href="./styles/editor.css" />
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f5f7fb;
+      --surface: #ffffff;
+      --border: #dde1eb;
+      --primary: #2563eb;
+      --text: #1f2937;
+      --muted: #6b7280;
+      --radius: 12px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: linear-gradient(180deg, rgba(241, 245, 249, 0.8), rgba(226, 232, 240, 1));
+      color: var(--text);
+    }
+
+    .app-shell {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header.app-header {
+      padding: 24px 32px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .header-title {
+      font-size: 24px;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .header-subtitle {
+      margin: 0;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    .config-panel {
+      display: flex;
+      gap: 16px;
+      align-items: flex-end;
+      flex-wrap: wrap;
+      background: rgba(255, 255, 255, 0.75);
+      padding: 16px;
+      border-radius: var(--radius);
+      border: 1px solid rgba(203, 213, 225, 0.5);
+      backdrop-filter: blur(12px);
+    }
+
+    .config-panel label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 12px;
+      color: var(--muted);
+      min-width: 240px;
+    }
+
+    .config-panel input {
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 14px;
+      width: 100%;
+    }
+
+    .config-panel button {
+      border: none;
+      background: var(--primary);
+      color: #fff;
+      font-size: 14px;
+      padding: 10px 18px;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .config-panel button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 18px rgba(37, 99, 235, 0.25);
+    }
+
+    .editor-container {
+      flex: 1;
+      padding: 0 32px 40px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .editor-surface {
+      background: var(--surface);
+      border-radius: var(--radius);
+      border: 1px solid rgba(203, 213, 225, 0.6);
+      box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.35);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      min-height: 480px;
+    }
+
+    .editor-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 16px 20px;
+      border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+      background: rgba(249, 250, 251, 0.9);
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      backdrop-filter: blur(10px);
+    }
+
+    .toolbar-button {
+      border: 1px solid transparent;
+      padding: 8px 12px;
+      border-radius: 999px;
+      font-size: 14px;
+      background: rgba(148, 163, 184, 0.12);
+      color: var(--text);
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .toolbar-button:hover {
+      border-color: rgba(148, 163, 184, 0.35);
+      background: rgba(148, 163, 184, 0.2);
+    }
+
+    .toolbar-button.active {
+      background: rgba(37, 99, 235, 0.12);
+      color: var(--primary);
+      border-color: rgba(37, 99, 235, 0.45);
+      box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.35);
+    }
+
+    .editor-content {
+      flex: 1;
+      padding: 24px 28px 48px;
+    }
+
+    .editor-content .ProseMirror {
+      min-height: 420px;
+      outline: none;
+      font-size: 16px;
+      line-height: 1.7;
+    }
+
+    .editor-content .ProseMirror p.is-editor-empty:first-child::before {
+      content: attr(data-placeholder);
+      color: rgba(148, 163, 184, 0.75);
+      float: left;
+      height: 0;
+      pointer-events: none;
+    }
+
+    .status-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 14px 20px;
+      font-size: 12px;
+      color: var(--muted);
+      background: rgba(248, 250, 252, 0.8);
+      border-top: 1px solid rgba(226, 232, 240, 0.8);
+    }
+
+    /* Template builder modal styles */
+    .template-builder-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.55);
+      display: none;
+      align-items: flex-start;
+      justify-content: center;
+      padding: 40px 24px;
+      overflow: auto;
+      z-index: 100;
+    }
+
+    .template-builder-overlay[data-visible="true"] {
+      display: flex;
+    }
+
+    .template-builder-dialog {
+      width: min(1200px, 100%);
+      background: #ffffff;
+      border-radius: 18px;
+      display: flex;
+      flex-direction: column;
+      box-shadow: 0 40px 60px -30px rgba(15, 23, 42, 0.45);
+      overflow: hidden;
+      animation: popIn 0.25s ease;
+    }
+
+    @keyframes popIn {
+      from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.98);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    .template-builder-header {
+      padding: 20px 24px;
+      border-bottom: 1px solid #edeff5;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+    }
+
+    .template-builder-header h2 {
+      margin: 0;
+      font-size: 20px;
+    }
+
+    .template-builder-sub {
+      margin: 6px 0 0;
+      font-size: 13px;
+      color: #6b7280;
+    }
+
+    .template-builder-close {
+      border: none;
+      background: rgba(148, 163, 184, 0.16);
+      width: 36px;
+      height: 36px;
+      border-radius: 12px;
+      cursor: pointer;
+      font-size: 18px;
+      line-height: 1;
+    }
+
+    .template-builder-body {
+      display: flex;
+      min-height: 640px;
+    }
+
+    .template-builder-sidebar {
+      width: 240px;
+      border-right: 1px solid #edeff5;
+      background: #f8fafc;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .template-list-toolbar {
+      display: flex;
+      gap: 8px;
+      padding: 16px;
+    }
+
+    .template-list-toolbar button {
+      flex: 1;
+      border: none;
+      background: rgba(148, 163, 184, 0.2);
+      padding: 10px 12px;
+      border-radius: 8px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+
+    .template-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px 16px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .template-list-empty {
+      font-size: 13px;
+      color: #94a3b8;
+      text-align: center;
+      padding: 24px 8px;
+    }
+
+    .template-list-item {
+      border: 1px solid transparent;
+      background: #ffffff;
+      padding: 12px 14px;
+      border-radius: 12px;
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      cursor: pointer;
+      transition: border 0.2s, box-shadow 0.2s;
+    }
+
+    .template-list-item:hover {
+      border-color: rgba(37, 99, 235, 0.35);
+      box-shadow: 0 8px 20px -14px rgba(37, 99, 235, 0.6);
+    }
+
+    .template-list-title {
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .template-list-meta {
+      font-size: 12px;
+      color: #64748b;
+    }
+
+    .template-builder-main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      padding: 20px 24px;
+      gap: 20px;
+    }
+
+    .template-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 16px;
+    }
+
+    .template-meta-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 12px;
+      color: #6b7280;
+    }
+
+    .template-meta-field input {
+      border: 1px solid #dbe1f0;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+    }
+
+    .breakpoint-toggle {
+      display: inline-flex;
+      gap: 6px;
+      background: #f1f5f9;
+      border-radius: 999px;
+      padding: 4px;
+    }
+
+    .breakpoint-toggle button {
+      border: none;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: transparent;
+      cursor: pointer;
+      font-size: 12px;
+      color: #64748b;
+    }
+
+    .breakpoint-toggle button.active {
+      background: #ffffff;
+      color: #2563eb;
+      font-weight: 600;
+      box-shadow: 0 4px 12px -6px rgba(37, 99, 235, 0.6);
+    }
+
+    .template-workspace {
+      display: grid;
+      grid-template-columns: 1.3fr 1fr;
+      gap: 20px;
+      align-items: start;
+    }
+
+    .template-canvas {
+      border: 1px dashed rgba(148, 163, 184, 0.6);
+      border-radius: 16px;
+      padding: 16px;
+      background: #fbfdff;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .canvas-node {
+      border: 1px solid rgba(203, 213, 225, 0.9);
+      border-radius: 12px;
+      background: #ffffff;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      transition: border 0.2s, box-shadow 0.2s;
+    }
+
+    .canvas-node.selected {
+      border-color: rgba(37, 99, 235, 0.6);
+      box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+    }
+
+    .canvas-node-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .canvas-node-title {
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .canvas-node-actions {
+      display: inline-flex;
+      gap: 6px;
+    }
+
+    .canvas-node-actions button {
+      border: none;
+      background: rgba(148, 163, 184, 0.16);
+      border-radius: 6px;
+      padding: 6px 8px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    .canvas-node-children {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding-left: 12px;
+      border-left: 2px dashed rgba(203, 213, 225, 0.8);
+    }
+
+    .canvas-add-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 8px;
+      border-radius: 10px;
+      background: rgba(148, 163, 184, 0.12);
+    }
+
+    .canvas-add-buttons button {
+      border: none;
+      background: #ffffff;
+      padding: 8px 10px;
+      border-radius: 8px;
+      font-size: 12px;
+      cursor: pointer;
+      border: 1px solid rgba(203, 213, 225, 0.7);
+    }
+
+    .canvas-add-none {
+      font-size: 12px;
+      color: #94a3b8;
+      margin: 0;
+    }
+
+    .canvas-add-menu {
+      position: absolute;
+      background: #ffffff;
+      border: 1px solid rgba(203, 213, 225, 0.9);
+      border-radius: 12px;
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      box-shadow: 0 18px 30px -18px rgba(15, 23, 42, 0.45);
+      z-index: 200;
+    }
+
+    .canvas-add-menu button {
+      border: none;
+      background: transparent;
+      padding: 8px 12px;
+      border-radius: 8px;
+      font-size: 13px;
+      text-align: left;
+      cursor: pointer;
+    }
+
+    .canvas-add-menu button:hover {
+      background: rgba(37, 99, 235, 0.1);
+    }
+
+    .template-properties {
+      border: 1px solid rgba(203, 213, 225, 0.8);
+      border-radius: 16px;
+      background: #ffffff;
+      display: flex;
+      flex-direction: column;
+      max-height: 480px;
+    }
+
+    .properties-header {
+      padding: 16px 18px;
+      border-bottom: 1px solid rgba(229, 231, 235, 0.8);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .properties-header h3 {
+      margin: 0;
+      font-size: 15px;
+    }
+
+    .properties-node-info {
+      font-size: 12px;
+      color: #94a3b8;
+      word-break: break-all;
+    }
+
+    .properties-content {
+      padding: 16px 18px;
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .properties-form {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .property-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 12px;
+      color: #6b7280;
+    }
+
+    .property-field input,
+    .property-field select,
+    .property-field textarea {
+      border: 1px solid rgba(203, 213, 225, 0.9);
+      border-radius: 8px;
+      padding: 8px 10px;
+      font-size: 14px;
+      font-family: inherit;
+    }
+
+    .property-field textarea {
+      min-height: 80px;
+      resize: vertical;
+    }
+
+    .properties-actions {
+      border-top: 1px solid rgba(229, 231, 235, 0.8);
+      padding: 12px 18px;
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .properties-actions .danger {
+      border: none;
+      background: rgba(248, 113, 113, 0.15);
+      color: #b91c1c;
+      padding: 8px 14px;
+      border-radius: 10px;
+      cursor: pointer;
+    }
+
+    .template-preview {
+      border: 1px solid rgba(203, 213, 225, 0.8);
+      border-radius: 16px;
+      background: #ffffff;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .preview-toolbar {
+      padding: 14px 18px;
+      border-bottom: 1px solid rgba(229, 231, 235, 0.8);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .preview-breakpoints {
+      display: inline-flex;
+      gap: 6px;
+      margin-right: auto;
+    }
+
+    .preview-breakpoints button {
+      border: none;
+      background: rgba(148, 163, 184, 0.2);
+      border-radius: 8px;
+      padding: 6px 12px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    .preview-breakpoints button.active {
+      background: rgba(37, 99, 235, 0.14);
+      color: #2563eb;
+    }
+
+    .preview-toolbar .primary {
+      border: none;
+      background: var(--primary);
+      color: #fff;
+      padding: 8px 14px;
+      border-radius: 10px;
+      cursor: pointer;
+      font-size: 13px;
+    }
+
+    .preview-viewport {
+      padding: 24px;
+      background: #f8fafc;
+      min-height: 280px;
+    }
+
+    .preview-wrapper {
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 24px;
+      min-height: 200px;
+      box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.5);
+    }
+
+    .preview-wrapper.preview-tablet {
+      width: 720px;
+      margin: 0 auto;
+    }
+
+    .preview-wrapper.preview-mobile {
+      width: 420px;
+      margin: 0 auto;
+    }
+
+    @media (max-width: 960px) {
+      .template-builder-body {
+        flex-direction: column;
+      }
+      .template-builder-sidebar {
+        width: auto;
+        border-right: none;
+        border-bottom: 1px solid #edeff5;
+      }
+      .template-workspace {
+        grid-template-columns: 1fr;
+      }
+      .preview-wrapper.preview-tablet,
+      .preview-wrapper.preview-mobile {
+        width: auto;
+      }
+    }
+  </style>
+  <script>
+    const storedTemplateBackend = localStorage.getItem('template-backend-url') || '';
+    const storedDriveBackend = localStorage.getItem('drive-image-webapp-url') || '';
+    window.TEMPLATE_BACKEND_URL = storedTemplateBackend;
+    window.DRIVE_IMAGE_WEBAPP_URL = storedDriveBackend;
+  </script>
+</head>
+<body>
+  <div class="app-shell">
+    <header class="app-header">
+      <div>
+        <h1 class="header-title">UIテンプレートビルダー付き TipTap</h1>
+        <p class="header-subtitle">レスポンシブなテンプレートを設計し、Wiki本文に挿入できます。</p>
+      </div>
+      <div class="config-panel">
+        <label>
+          Template Backend URL
+          <input id="template-backend-url" type="url" placeholder="https://script.google.com/.../exec" value="" />
+        </label>
+        <label>
+          DriveImage WebApp URL
+          <input id="drive-backend-url" type="url" placeholder="https://script.google.com/.../exec" value="" />
+        </label>
+        <button id="save-config" type="button">設定を保存して再読み込み</button>
+      </div>
+    </header>
+
+    <main class="editor-container">
+      <section class="editor-surface">
+        <div id="editor-toolbar" class="editor-toolbar"></div>
+        <div class="editor-content">
+          <div id="editor" class="editor"></div>
+        </div>
+        <footer class="status-footer">
+          <span id="status-message">テンプレートビルダーは「テンプレート」ボタンから開きます。</span>
+          <span id="status-meta"></span>
+        </footer>
+      </section>
+    </main>
+  </div>
+
+  <script type="module">
+    import { Editor } from 'https://esm.sh/@tiptap/core';
+    import { StarterKit } from 'https://esm.sh/@tiptap/starter-kit';
+    import { Placeholder } from 'https://esm.sh/@tiptap/extension-placeholder';
+    import { Link } from 'https://esm.sh/@tiptap/extension-link';
+    import { TemplateBuilderExtension } from './extensions/templateBuilder/TemplateBuilderExtension.js';
+    import { TemplateStore } from './scripts/templateStore.js';
+    import { DriveImageExtension } from './extensions/driveImage/DriveImageExtension.js';
+    import { ResizableImage } from './extensions/resizableImage/ResizableImage.js';
+
+    const templateBackendInput = document.getElementById('template-backend-url');
+    const driveBackendInput = document.getElementById('drive-backend-url');
+    const saveConfigButton = document.getElementById('save-config');
+
+    templateBackendInput.value = window.TEMPLATE_BACKEND_URL || '';
+    driveBackendInput.value = window.DRIVE_IMAGE_WEBAPP_URL || '';
+
+    saveConfigButton.addEventListener('click', () => {
+      localStorage.setItem('template-backend-url', templateBackendInput.value.trim());
+      localStorage.setItem('drive-image-webapp-url', driveBackendInput.value.trim());
+      window.location.reload();
+    });
+
+    const toolbarElement = document.getElementById('editor-toolbar');
+
+    function createToolbarButton(label, command) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'toolbar-button';
+      button.textContent = label;
+      button.addEventListener('click', () => {
+        command();
+        updateToolbarState();
+      });
+      return button;
+    }
+
+    const templateStore = window.TEMPLATE_BACKEND_URL
+      ? new TemplateStore({ endpoint: window.TEMPLATE_BACKEND_URL })
+      : null;
+
+    const editor = new Editor({
+      element: document.querySelector('#editor'),
+      autofocus: true,
+      extensions: [
+        StarterKit.configure({
+          heading: { levels: [1, 2, 3, 4] },
+          bulletList: { keepMarks: true },
+          orderedList: { keepMarks: true }
+        }),
+        Placeholder.configure({
+          placeholder: 'ここにWiki本文を入力し、テンプレートを挿入してください。'
+        }),
+        Link.configure({
+          openOnClick: false,
+          autolink: true,
+          linkOnPaste: true
+        }),
+        ResizableImage.configure({ inline: false }),
+        DriveImageExtension.configure({
+          toolbarSelector: '#editor-toolbar',
+          buttonClass: 'toolbar-button',
+          webAppUrl: window.DRIVE_IMAGE_WEBAPP_URL || '',
+          addToToolbar: true,
+          toolbarButtonHTML: '🖼️',
+          toolbarButtonTitle: 'Drive画像'
+        }),
+        TemplateBuilderExtension.configure({
+          toolbarSelector: '#editor-toolbar',
+          buttonClass: 'toolbar-button',
+          buttonLabel: 'テンプレート',
+          store: templateStore
+        })
+      ],
+      content: `
+        <h2>テンプレートビルダーのサンプルページ</h2>
+        <p>上部ツールバーの <strong>テンプレート</strong> ボタンから新規テンプレートを設計できます。保存すると一覧に反映され、エディタへ挿入が可能です。</p>
+        <p>レスポンシブ設定は Base / Desktop / Tablet / Mobile で切り替えて編集します。</p>
+      `
+    });
+
+    const toolbarButtons = [
+      createToolbarButton('太字', () => editor.chain().focus().toggleBold().run()),
+      createToolbarButton('斜体', () => editor.chain().focus().toggleItalic().run()),
+      createToolbarButton('H2', () => editor.chain().focus().toggleHeading({ level: 2 }).run()),
+      createToolbarButton('箇条書き', () => editor.chain().focus().toggleBulletList().run()),
+      createToolbarButton('番号リスト', () => editor.chain().focus().toggleOrderedList().run()),
+      createToolbarButton('引用', () => editor.chain().focus().toggleBlockquote().run())
+    ];
+
+    toolbarButtons.forEach((btn) => toolbarElement.appendChild(btn));
+
+    function updateToolbarState() {
+      toolbarButtons[0].classList.toggle('active', editor.isActive('bold'));
+      toolbarButtons[1].classList.toggle('active', editor.isActive('italic'));
+      toolbarButtons[2].classList.toggle('active', editor.isActive('heading', { level: 2 }));
+      toolbarButtons[3].classList.toggle('active', editor.isActive('bulletList'));
+      toolbarButtons[4].classList.toggle('active', editor.isActive('orderedList'));
+      toolbarButtons[5].classList.toggle('active', editor.isActive('blockquote'));
+    }
+
+    editor.on('transaction', updateToolbarState);
+    updateToolbarState();
+
+    window.editor = editor;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a TemplateBuilder tiptap extension that provides a modal UI for building responsive template JSON structures and inserting them into the editor
- introduce a browser TemplateStore helper and a Google Apps Script backend for persisting template metadata in Sheets
- create a new tiptap-image5 demo page that wires the template builder, DriveImage integration, and configurable backend endpoints together

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e7069620832b915c2841c2cf4bb7