### PR TITLE
Add live preview and placeholders to UI template builder

### DIFF
--- a/extensions/ui-template.js
+++ b/extensions/ui-template.js
@@ -1,0 +1,684 @@
+import { Extension } from 'https://esm.sh/@tiptap/core';
+
+const ALIGN_OPTIONS = [
+    { value: 'left', label: '左寄せ' },
+    { value: 'center', label: '中央寄せ' },
+    { value: 'right', label: '右寄せ' }
+];
+
+const DIRECTION_OPTIONS = [
+    { value: 'column', label: '縦並び' },
+    { value: 'row', label: '横並び' }
+];
+
+let elementIdCounter = 0;
+
+function createElementId() {
+    elementIdCounter += 1;
+    return `tpl-el-${Date.now()}-${elementIdCounter}`;
+}
+
+function escapeHtml(value) {
+    return (value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value) {
+    return escapeHtml(value).replace(/\n/g, ' ');
+}
+
+function normalizeSpacing(value) {
+    const trimmed = (value ?? '').toString().trim();
+    return trimmed ? trimmed : '0';
+}
+
+function alignToFlex(align) {
+    switch (align) {
+        case 'center':
+            return 'center';
+        case 'right':
+            return 'flex-end';
+        default:
+            return 'flex-start';
+    }
+}
+
+function alignToText(align) {
+    if (align === 'center') {
+        return 'center';
+    }
+    if (align === 'right') {
+        return 'right';
+    }
+    return 'left';
+}
+
+function cloneElement(element) {
+    return {
+        id: element.id,
+        type: element.type,
+        padding: element.padding,
+        margin: element.margin,
+        align: element.align,
+        direction: element.direction,
+        gap: element.gap,
+        content: element.content,
+        src: element.src,
+        children: (element.children || []).map(child => cloneElement(child))
+    };
+}
+
+function buildElementsMarkup(elements, baseClass, pathPrefix = []) {
+    const htmlParts = [];
+    const cssParts = [];
+
+    elements.forEach((element, index) => {
+        const path = [...pathPrefix, index + 1];
+        const type = element.type || 'frame';
+        const className = `${baseClass}__${type}-${path.join('-')}`;
+        const margin = normalizeSpacing(element.margin);
+        const padding = normalizeSpacing(element.padding);
+        const align = element.align || 'left';
+        if (type === 'frame') {
+            const direction = element.direction === 'row' ? 'row' : 'column';
+            const gap = normalizeSpacing(element.gap ?? '12px');
+            const { html: childHtml, css: childCss } = buildElementsMarkup(element.children || [], baseClass, path);
+            htmlParts.push(`<div class="${className}" data-template-frame="${direction}">${childHtml}</div>`);
+            cssParts.push(`.${className} { display: flex; flex-direction: ${direction}; gap: ${gap}; padding: ${padding}; margin: ${margin}; align-items: ${alignToFlex(align)}; width: 100%; }`);
+            if (childCss) {
+                cssParts.push(childCss);
+            }
+        } else if (type === 'image') {
+            const src = escapeAttribute(element.src || '');
+            const placeholderClass = `${className}__placeholder`;
+            const placeholder = `<div class="${placeholderClass}" data-template-image-placeholder="true" aria-label="画像を挿入">画像を挿入</div>`;
+            htmlParts.push(`<div class="${className}" data-template-image="true" data-template-placeholder-class="${placeholderClass}">${src ? `<img src="${src}" alt="" />` : placeholder}</div>`);
+            const alignRule = alignToText(align);
+            cssParts.push(`.${className} { padding: ${padding}; margin: ${margin}; text-align: ${alignRule}; }`);
+            cssParts.push(`.${className} > img { max-width: 100%; height: auto; display: inline-block; }`);
+            cssParts.push(`.${className}__placeholder { border: 1px dashed #adb5bd; border-radius: 8px; color: #868e96; font-size: 14px; padding: 24px 16px; display: inline-flex; align-items: center; justify-content: center; width: 100%; min-height: 120px; cursor: pointer; background: #f8f9fa; }`);
+            cssParts.push(`.${className}__placeholder:hover { background: #f1f3f5; color: #495057; }`);
+        } else {
+            const content = escapeHtml(element.content || '');
+            const alignRule = alignToText(align);
+            const displayContent = content ? content.replace(/\n/g, '<br>') : '<span class="ui-template-text-placeholder" data-template-text-placeholder="true">テキストを入力</span>';
+            htmlParts.push(`<div class="${className}" data-template-text="true">${displayContent}</div>`);
+            cssParts.push(`.${className} { padding: ${padding}; margin: ${margin}; text-align: ${alignRule}; white-space: pre-wrap; word-break: break-word; }`);
+        }
+    });
+
+    return {
+        html: htmlParts.join(''),
+        css: cssParts.join('\n')
+    };
+}
+
+function buildTemplateOutput(id, elements) {
+    const baseClass = `ui-template-${id}`;
+    const { html, css } = buildElementsMarkup(elements, baseClass);
+    const htmlOutput = `<div class="ui-template-block ${baseClass}">${html}</div>`;
+    const cssOutput = [
+        `.ui-template-block.${baseClass} { display: flex; flex-direction: column; gap: 16px; width: 100%; }`,
+        `.ui-template-block.${baseClass} [data-template-text-placeholder="true"] { color: #adb5bd; font-size: 14px; font-style: italic; }`,
+        css
+    ].filter(Boolean).join('\n');
+    return { html: htmlOutput, css: cssOutput };
+}
+
+function createBaseElement(type = 'text') {
+    const base = {
+        id: createElementId(),
+        type,
+        padding: '',
+        margin: '',
+        align: 'left',
+        content: '',
+        src: '',
+        children: []
+    };
+    if (type === 'frame') {
+        base.direction = 'column';
+        base.gap = '12px';
+    }
+    return base;
+}
+
+export class TemplateManager {
+    constructor(options) {
+        this.getEditor = options.getEditor;
+        this.modal = options.modal;
+        this.listView = options.listView;
+        this.listContainer = options.listContainer;
+        this.openCreatorButton = options.openCreatorButton;
+        this.creatorView = options.creatorView;
+        this.templateForm = options.templateForm;
+        this.templateNameInput = options.templateNameInput;
+        this.elementList = options.elementList;
+        this.addElementButton = options.addElementButton;
+        this.cancelCreateButton = options.cancelCreateButton;
+        this.closeButton = options.closeButton;
+        this.backdrop = options.backdrop;
+        this.previewContainer = options.previewContainer;
+        this.templates = [];
+        this.currentDraft = null;
+        this.styleElement = null;
+        this.appliedTemplateIds = new Set();
+        this.imagePlaceholderHandler = null;
+        this.templateUpdateHandler = null;
+        this.bindEvents();
+        this.renderTemplateList();
+        this.attachTemplateInteractions();
+    }
+
+    bindEvents() {
+        this.openCreatorButton?.addEventListener('click', () => this.startDraft());
+        this.addElementButton?.addEventListener('click', () => {
+            if (!this.currentDraft) {
+                this.startDraft();
+            }
+            this.currentDraft.elements.push(createBaseElement());
+            this.renderCreatorView();
+        });
+        this.cancelCreateButton?.addEventListener('click', () => {
+            this.currentDraft = null;
+            this.showListView();
+        });
+        this.templateForm?.addEventListener('submit', event => {
+            event.preventDefault();
+            this.saveDraft();
+        });
+        this.closeButton?.addEventListener('click', () => this.close());
+        this.backdrop?.addEventListener('click', () => this.close());
+        document.addEventListener('keydown', event => {
+            if (event.key === 'Escape' && this.modal?.classList.contains('visible')) {
+                this.close();
+            }
+        });
+    }
+
+    ensureStyleElement() {
+        if (this.styleElement) {
+            return this.styleElement;
+        }
+        const style = document.createElement('style');
+        style.id = 'ui-template-style-registry';
+        document.head.appendChild(style);
+        this.styleElement = style;
+        return style;
+    }
+
+    ensureTemplateStyles(template) {
+        if (!template || !template.id || !template.css) {
+            return;
+        }
+        if (this.appliedTemplateIds.has(template.id)) {
+            return;
+        }
+        const style = this.ensureStyleElement();
+        style.appendChild(document.createTextNode(`\n/* template:${template.id} */\n${template.css}\n`));
+        this.appliedTemplateIds.add(template.id);
+        this.attachTemplateInteractions();
+    }
+
+    open() {
+        if (!this.modal) return;
+        this.modal.classList.add('visible');
+        this.modal.setAttribute('aria-hidden', 'false');
+        this.showListView();
+    }
+
+    close() {
+        if (!this.modal) return;
+        this.modal.classList.remove('visible');
+        this.modal.setAttribute('aria-hidden', 'true');
+        this.currentDraft = null;
+        this.templateNameInput && (this.templateNameInput.value = '');
+        if (this.previewContainer) {
+            this.previewContainer.innerHTML = '';
+        }
+    }
+
+    showListView() {
+        if (this.listView) {
+            this.listView.removeAttribute('hidden');
+        }
+        if (this.creatorView) {
+            this.creatorView.setAttribute('hidden', 'true');
+        }
+        this.renderTemplateList();
+        if (this.previewContainer) {
+            this.previewContainer.innerHTML = '';
+        }
+    }
+
+    startDraft() {
+        this.currentDraft = {
+            elements: []
+        };
+        if (this.templateNameInput) {
+            this.templateNameInput.value = '';
+        }
+        this.showCreatorView();
+    }
+
+    showCreatorView() {
+        if (this.listView) {
+            this.listView.setAttribute('hidden', 'true');
+        }
+        if (this.creatorView) {
+            this.creatorView.removeAttribute('hidden');
+        }
+        this.renderCreatorView();
+    }
+
+    renderTemplateList() {
+        if (!this.listContainer) return;
+        this.listContainer.innerHTML = '';
+        if (!this.templates.length) {
+            const empty = document.createElement('div');
+            empty.className = 'template-empty-state';
+            empty.textContent = 'テンプレートがまだありません。\n「テンプレート作成」から追加してください。';
+            this.listContainer.appendChild(empty);
+            return;
+        }
+        this.templates.forEach(template => {
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'template-item';
+            item.textContent = template.name;
+            item.addEventListener('click', () => {
+                const editor = this.getEditor?.();
+                if (!editor) {
+                    return;
+                }
+                editor.commands.insertTemplate({ template });
+                this.close();
+            });
+            this.listContainer.appendChild(item);
+        });
+    }
+
+    renderCreatorView() {
+        if (!this.elementList) return;
+        this.elementList.innerHTML = '';
+        if (!this.currentDraft) {
+            this.renderPreview();
+            return;
+        }
+        const elements = this.currentDraft.elements || [];
+        if (!elements.length) {
+            const hint = document.createElement('div');
+            hint.className = 'template-empty-elements';
+            hint.textContent = '「要素を追加」ボタンからフレーム・テキスト・イメージを追加できます。';
+            this.elementList.appendChild(hint);
+            this.renderPreview();
+            return;
+        }
+        elements.forEach((element, index) => {
+            const node = this.createElementEditor(element, elements, index, 0);
+            this.elementList.appendChild(node);
+        });
+        this.renderPreview();
+    }
+
+    createElementEditor(element, siblings, index, depth) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'template-element-editor';
+        wrapper.style.marginLeft = `${depth * 16}px`;
+
+        const header = document.createElement('div');
+        header.className = 'template-element-header';
+
+        const typeSelect = document.createElement('select');
+        typeSelect.className = 'template-element-type';
+        ['frame', 'text', 'image'].forEach(type => {
+            const option = document.createElement('option');
+            option.value = type;
+            option.textContent = type === 'frame' ? 'フレーム' : type === 'text' ? 'テキスト' : 'イメージ';
+            if (element.type === type) {
+                option.selected = true;
+            }
+            typeSelect.appendChild(option);
+        });
+        typeSelect.addEventListener('change', () => {
+            const selected = typeSelect.value;
+            if (selected === 'frame') {
+                element.type = 'frame';
+                element.content = '';
+                element.src = '';
+                element.children = element.children || [];
+                element.direction = element.direction || 'column';
+                element.gap = element.gap || '12px';
+            } else if (selected === 'image') {
+                element.type = 'image';
+                element.children = [];
+                element.content = '';
+                element.src = element.src || '';
+            } else {
+                element.type = 'text';
+                element.children = [];
+                element.content = element.content || '';
+                element.src = '';
+            }
+            this.renderCreatorView();
+        });
+
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.className = 'template-element-remove';
+        removeButton.textContent = '削除';
+        removeButton.addEventListener('click', () => {
+            siblings.splice(index, 1);
+            this.renderCreatorView();
+        });
+
+        header.appendChild(typeSelect);
+        header.appendChild(removeButton);
+        wrapper.appendChild(header);
+
+        const controls = document.createElement('div');
+        controls.className = 'template-element-controls';
+
+        const paddingLabel = document.createElement('label');
+        paddingLabel.textContent = 'Padding';
+        const paddingInput = document.createElement('input');
+        paddingInput.type = 'text';
+        paddingInput.value = element.padding || '';
+        paddingInput.placeholder = '例: 16px 12px';
+        paddingInput.addEventListener('input', () => {
+            element.padding = paddingInput.value;
+            this.renderPreview();
+        });
+        paddingLabel.appendChild(paddingInput);
+        controls.appendChild(paddingLabel);
+
+        const marginLabel = document.createElement('label');
+        marginLabel.textContent = 'Margin';
+        const marginInput = document.createElement('input');
+        marginInput.type = 'text';
+        marginInput.value = element.margin || '';
+        marginInput.placeholder = '例: 8px 0';
+        marginInput.addEventListener('input', () => {
+            element.margin = marginInput.value;
+            this.renderPreview();
+        });
+        marginLabel.appendChild(marginInput);
+        controls.appendChild(marginLabel);
+
+        const alignLabel = document.createElement('label');
+        alignLabel.textContent = 'Align';
+        const alignSelect = document.createElement('select');
+        ALIGN_OPTIONS.forEach(optionInfo => {
+            const option = document.createElement('option');
+            option.value = optionInfo.value;
+            option.textContent = optionInfo.label;
+            if (element.align === optionInfo.value) {
+                option.selected = true;
+            }
+            alignSelect.appendChild(option);
+        });
+        alignSelect.addEventListener('change', () => {
+            element.align = alignSelect.value;
+            this.renderPreview();
+        });
+        alignLabel.appendChild(alignSelect);
+        controls.appendChild(alignLabel);
+
+        if (element.type === 'frame') {
+            const directionLabel = document.createElement('label');
+            directionLabel.textContent = 'レイアウト';
+            const directionSelect = document.createElement('select');
+            DIRECTION_OPTIONS.forEach(optionInfo => {
+                const option = document.createElement('option');
+                option.value = optionInfo.value;
+                option.textContent = optionInfo.label;
+                if ((element.direction || 'column') === optionInfo.value) {
+                    option.selected = true;
+                }
+                directionSelect.appendChild(option);
+            });
+            directionSelect.addEventListener('change', () => {
+                element.direction = directionSelect.value;
+                this.renderPreview();
+            });
+            directionLabel.appendChild(directionSelect);
+            controls.appendChild(directionLabel);
+
+            const gapLabel = document.createElement('label');
+            gapLabel.textContent = 'Gap';
+            const gapInput = document.createElement('input');
+            gapInput.type = 'text';
+            gapInput.value = element.gap || '';
+            gapInput.placeholder = '例: 12px';
+            gapInput.addEventListener('input', () => {
+                element.gap = gapInput.value;
+                this.renderPreview();
+            });
+            gapLabel.appendChild(gapInput);
+            controls.appendChild(gapLabel);
+        }
+
+        wrapper.appendChild(controls);
+
+        if (element.type === 'text') {
+            const contentLabel = document.createElement('label');
+            contentLabel.textContent = 'テキスト内容';
+            const textarea = document.createElement('textarea');
+            textarea.value = element.content || '';
+            textarea.rows = 3;
+            textarea.addEventListener('input', () => {
+                element.content = textarea.value;
+                this.renderPreview();
+            });
+            contentLabel.appendChild(textarea);
+            wrapper.appendChild(contentLabel);
+        } else if (element.type === 'image') {
+            const srcLabel = document.createElement('label');
+            srcLabel.textContent = '画像URL';
+            const srcInput = document.createElement('input');
+            srcInput.type = 'text';
+            srcInput.value = element.src || '';
+            srcInput.placeholder = 'https://example.com/image.png';
+            srcInput.addEventListener('input', () => {
+                element.src = srcInput.value;
+                this.renderPreview();
+            });
+            srcLabel.appendChild(srcInput);
+            wrapper.appendChild(srcLabel);
+        } else if (element.type === 'frame') {
+            const childContainer = document.createElement('div');
+            childContainer.className = 'template-element-children';
+            const children = element.children || [];
+            if (children.length) {
+                children.forEach((child, childIndex) => {
+                    const childEditor = this.createElementEditor(child, children, childIndex, depth + 1);
+                    childContainer.appendChild(childEditor);
+                });
+            }
+            const addChildButton = document.createElement('button');
+            addChildButton.type = 'button';
+            addChildButton.className = 'template-add-child';
+            addChildButton.textContent = '子要素を追加';
+            addChildButton.addEventListener('click', () => {
+                children.push(createBaseElement());
+                this.renderCreatorView();
+            });
+            childContainer.appendChild(addChildButton);
+            wrapper.appendChild(childContainer);
+        }
+
+        return wrapper;
+    }
+
+    validateElements(elements) {
+        if (!elements || !elements.length) {
+            return false;
+        }
+        for (const element of elements) {
+            if (element.type === 'frame') {
+                if (!this.validateElements(element.children || [])) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    renderPreview() {
+        if (!this.previewContainer) {
+            return;
+        }
+        this.previewContainer.innerHTML = '';
+        if (!this.currentDraft || !this.currentDraft.elements || !this.currentDraft.elements.length) {
+            const empty = document.createElement('div');
+            empty.className = 'template-preview-empty';
+            empty.textContent = 'テンプレートのプレビューがここに表示されます。';
+            this.previewContainer.appendChild(empty);
+            return;
+        }
+        const previewElements = this.currentDraft.elements.map(element => cloneElement(element));
+        const previewId = `preview-${Date.now()}`;
+        const { html, css } = buildTemplateOutput(previewId, previewElements);
+        const style = document.createElement('style');
+        style.textContent = css;
+        const stage = document.createElement('div');
+        stage.className = 'template-preview-stage';
+        stage.innerHTML = html;
+        this.previewContainer.appendChild(style);
+        this.previewContainer.appendChild(stage);
+    }
+
+    attachTemplateInteractions() {
+        if (this.imagePlaceholderHandler) {
+            return;
+        }
+        const editor = this.getEditor?.();
+        if (!editor) {
+            return;
+        }
+        const editorDom = editor.view?.dom;
+        if (!editorDom) {
+            return;
+        }
+        this.imagePlaceholderHandler = event => {
+            const container = event.target.closest('[data-template-image="true"]');
+            if (!container || !editorDom.contains(container)) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const view = editor.view;
+            let fromPos = 0;
+            try {
+                fromPos = view.posAtDOM(container, 0) + 1;
+            } catch (error) {
+                fromPos = editor.state.selection.from;
+            }
+            editor.chain().focus().setTextSelection({ from: fromPos, to: fromPos }).run();
+            if (typeof editor.commands.insertImageFromGallery === 'function') {
+                editor.commands.insertImageFromGallery();
+            } else if (typeof editor.commands.openImageModal === 'function') {
+                editor.commands.openImageModal();
+            }
+        };
+        editorDom.addEventListener('click', this.imagePlaceholderHandler);
+
+        if (!this.templateUpdateHandler && typeof editor.on === 'function') {
+            this.templateUpdateHandler = () => {
+                const root = editor.view?.dom;
+                if (!root) {
+                    return;
+                }
+                const containers = root.querySelectorAll('[data-template-image="true"]');
+                containers.forEach(container => {
+                    const placeholderNode = container.querySelector('[data-template-image-placeholder]');
+                    const images = Array.from(container.querySelectorAll('img'));
+                    if (images.length) {
+                        if (placeholderNode) {
+                            placeholderNode.remove();
+                        }
+                        if (images.length > 1) {
+                            images.slice(1).forEach(img => img.remove());
+                        }
+                    } else if (!placeholderNode) {
+                        const placeholderClass = container.getAttribute('data-template-placeholder-class');
+                        if (placeholderClass) {
+                            const placeholder = document.createElement('div');
+                            placeholder.className = placeholderClass;
+                            placeholder.setAttribute('data-template-image-placeholder', 'true');
+                            placeholder.setAttribute('aria-label', '画像を挿入');
+                            placeholder.textContent = '画像を挿入';
+                            container.appendChild(placeholder);
+                        }
+                    }
+                });
+            };
+            editor.on('update', this.templateUpdateHandler);
+            this.templateUpdateHandler();
+        }
+    }
+
+    saveDraft() {
+        if (!this.currentDraft) {
+            return;
+        }
+        const name = (this.templateNameInput?.value || '').trim();
+        if (!name) {
+            alert('テンプレート名を入力してください。');
+            return;
+        }
+        if (!this.validateElements(this.currentDraft.elements)) {
+            alert('テンプレートには少なくとも1つの要素が必要です。');
+            return;
+        }
+        const id = `tpl-${Date.now()}`;
+        const clonedElements = (this.currentDraft.elements || []).map(element => cloneElement(element));
+        const { html, css } = buildTemplateOutput(id, clonedElements);
+        const template = {
+            id,
+            name,
+            elements: clonedElements,
+            html,
+            css
+        };
+        this.templates.push(template);
+        this.ensureTemplateStyles(template);
+        this.currentDraft = null;
+        this.showListView();
+    }
+}
+
+export const UITemplateExtension = Extension.create({
+    name: 'uiTemplate',
+    addOptions() {
+        return {
+            getManager: () => null
+        };
+    },
+    addCommands() {
+        return {
+            openTemplateManager: () => () => {
+                const manager = this.options.getManager?.();
+                if (!manager) {
+                    return false;
+                }
+                manager.open();
+                return true;
+            },
+            insertTemplate: options => ({ editor }) => {
+                const template = options?.template;
+                if (!template?.html) {
+                    return false;
+                }
+                editor.chain().focus().insertContent(template.html).run();
+                const manager = this.options.getManager?.();
+                manager?.ensureTemplateStyles(template);
+                return true;
+            }
+        };
+    }
+});

--- a/tiptap-image5.html
+++ b/tiptap-image5.html
@@ -1,0 +1,2710 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wiki with TipTap</title>
+    <link rel="stylesheet" href="./styles/editor.css">
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            background: #f5f5f5;
+            color: #37352f;
+        }
+
+        .app-container {
+            display: flex;
+            height: 100vh;
+            width: 100vw;
+        }
+
+        .sidebar {
+            width: 280px;
+            background: #f7f6f3;
+            border-right: 1px solid #e9e9e7;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .sidebar-header {
+            padding: 20px 24px 12px;
+            border-bottom: 1px solid #e9e9e7;
+        }
+
+        .sidebar-title {
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .sidebar-actions {
+            display: flex;
+            gap: 8px;
+            padding: 12px 24px;
+            border-bottom: 1px solid #e9e9e7;
+        }
+
+        .sidebar-actions .btn {
+            flex: 1;
+        }
+
+        .page-tree {
+            flex: 1;
+            overflow-y: auto;
+            padding: 12px 8px 24px 16px;
+        }
+
+        .tree-list,
+        .tree-list ul {
+            list-style: none;
+            margin: 0;
+            padding-left: 16px;
+        }
+
+        .tree-list > li {
+            padding-left: 0;
+        }
+
+        .tree-item {
+            padding: 4px 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            color: #37352f;
+            position: relative;
+        }
+
+        .tree-item:hover {
+            background: #e9e9e7;
+        }
+
+        .tree-item.active {
+            background: #2383e2;
+            color: #fff;
+        }
+
+        .tree-item.dragging {
+            opacity: 0.5;
+        }
+
+        .tree-item.drop-target,
+        .tree-list.drop-target,
+        .tree-children.drop-target {
+            outline: 2px dashed #2383e2;
+            outline-offset: 2px;
+        }
+
+        .tree-item.drop-before {
+            box-shadow: inset 0 3px 0 #2383e2;
+        }
+
+        .tree-item.drop-after {
+            box-shadow: inset 0 -3px 0 #2383e2;
+        }
+
+        .tree-item.drop-inside {
+            outline: 2px dashed #2383e2;
+            outline-offset: 2px;
+        }
+
+        .tree-drop-zone {
+            position: relative;
+            height: 8px;
+            margin: 2px 0;
+            border-radius: 999px;
+            list-style: none;
+        }
+
+        .tree-drop-zone::after {
+            content: '';
+            position: absolute;
+            left: 8px;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            border-top: 2px dashed transparent;
+        }
+
+        .tree-drop-zone.active::after {
+            border-color: #2383e2;
+        }
+
+        .tree-children {
+            margin-left: 12px;
+            border-left: 1px solid #e0dfdc;
+            padding-left: 12px;
+        }
+
+        .main-area {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+        }
+
+        .page-header {
+            padding: 16px 32px 0;
+            border-bottom: 1px solid #e9e9e7;
+            background: #fff;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            position: sticky;
+            top: 0;
+            z-index: 30;
+        }
+
+        .page-header.is-scrolled {
+            box-shadow: 0 6px 12px rgba(15, 23, 42, 0.12);
+            border-bottom-color: transparent;
+        }
+
+        .page-header-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .input-group {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            min-width: 200px;
+        }
+
+        .input-label {
+            font-size: 12px;
+            font-weight: 600;
+            color: #6b6b67;
+        }
+
+        .text-input {
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid #d3d2ce;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        .text-input:disabled {
+            background: #f1f1ef;
+            color: #9b9a97;
+        }
+
+        .header-actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        .btn {
+            padding: 8px 14px;
+            border-radius: 6px;
+            border: 1px solid #d3d2ce;
+            background: #fff;
+            color: #37352f;
+            font-size: 13px;
+            cursor: pointer;
+            transition: background 0.2s, border 0.2s;
+        }
+
+        .btn:hover {
+            background: #f7f6f3;
+        }
+
+        .btn-primary {
+            background: #2383e2;
+            border-color: #2383e2;
+            color: #fff;
+        }
+
+        .btn-primary:hover {
+            background: #1a6bc2;
+        }
+
+        .editor-wrapper {
+            flex: 1;
+            overflow-y: auto;
+            padding: 32px;
+            background: #f8f8f7;
+            --page-header-height: 0px;
+            scroll-padding-top: calc(var(--page-header-height, 0px) + 16px);
+        }
+
+        .editor-container {
+            max-width: 860px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+        }
+
+        .youtube-paste-popup {
+            position: absolute;
+            top: 0;
+            left: 0;
+            display: none;
+            flex-direction: column;
+            gap: 12px;
+            padding: 14px 16px;
+            background: #fff;
+            border: 1px solid #d3d2ce;
+            border-radius: 10px;
+            box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
+            z-index: 40;
+            min-width: 240px;
+        }
+
+        .youtube-paste-popup.visible {
+            display: flex;
+        }
+
+        .youtube-paste-popup-message {
+            font-size: 13px;
+            color: #37352f;
+            line-height: 1.5;
+        }
+
+        .youtube-paste-popup-actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        .youtube-paste-popup-actions .btn {
+            flex: 1;
+            white-space: nowrap;
+        }
+
+        .youtube-embed {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            border: 0;
+            border-radius: 12px;
+            background: #000;
+        }
+
+        .loading-overlay {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(55, 53, 47, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            z-index: 1000;
+        }
+
+        .loading-overlay.visible {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .loading-popup {
+            background: #fff;
+            padding: 28px 36px;
+            border-radius: 14px;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 18px;
+            min-width: 260px;
+        }
+
+        .loading-spinner {
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            border: 4px solid #e9e9e7;
+            border-top-color: #2383e2;
+            animation: loading-spin 1s linear infinite;
+        }
+
+        @keyframes loading-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        .loading-message {
+            font-size: 15px;
+            color: #37352f;
+            font-weight: 500;
+            text-align: center;
+        }
+
+        .editor-image {
+            max-width: 100%;
+            height: auto;
+            border-radius: 6px;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+        }
+
+        .resizable-image {
+            position: relative;
+            display: inline-block;
+            max-width: 100%;
+        }
+
+        .resizable-image img {
+            display: block;
+            max-width: 100%;
+            height: auto;
+        }
+
+        .resizable-image.is-selected img {
+            outline: 2px solid rgba(35, 131, 226, 0.5);
+            outline-offset: 2px;
+        }
+
+        .resize-handle {
+            position: absolute;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #2383e2;
+            border: 2px solid #fff;
+            box-shadow: 0 2px 6px rgba(15, 23, 42, 0.25);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            touch-action: none;
+            z-index: 5;
+        }
+
+        .resizable-image.is-selected .resize-handle {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .resize-handle-n { top: 0; left: 50%; transform: translate(-50%, -50%); cursor: ns-resize; }
+        .resize-handle-s { bottom: 0; left: 50%; transform: translate(-50%, 50%); cursor: ns-resize; }
+        .resize-handle-e { top: 50%; right: 0; transform: translate(50%, -50%); cursor: ew-resize; }
+        .resize-handle-w { top: 50%; left: 0; transform: translate(-50%, -50%); cursor: ew-resize; }
+        .resize-handle-ne { top: 0; right: 0; transform: translate(50%, -50%); cursor: nesw-resize; }
+        .resize-handle-nw { top: 0; left: 0; transform: translate(-50%, -50%); cursor: nwse-resize; }
+        .resize-handle-se { bottom: 0; right: 0; transform: translate(50%, 50%); cursor: nwse-resize; }
+        .resize-handle-sw { bottom: 0; left: 0; transform: translate(-50%, 50%); cursor: nesw-resize; }
+
+        .toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            padding: 12px 32px;
+            margin: 0 -32px;
+            border-top: 1px solid #edeceb;
+            background: #f9f9f8;
+        }
+
+        .toolbar button {
+            border: 1px solid transparent;
+            background: none;
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-size: 15px;
+            cursor: pointer;
+            color: #494848;
+        }
+
+        .toolbar button:hover {
+            background: #ececec;
+            border-color: #d0d0ce;
+        }
+
+        .toolbar button.active {
+            background: #2383e2;
+            color: #fff;
+            border-color: #2383e2;
+        }
+
+        .link-editor-bar {
+            display: none;
+            gap: 8px;
+            padding: 12px 16px;
+            border-bottom: 1px solid #edeceb;
+            background: #fff;
+            align-items: center;
+            flex-wrap: wrap;
+            position: sticky;
+            top: 0;
+            z-index: 25;
+        }
+
+        .link-editor-bar.visible {
+            display: flex;
+        }
+
+        .link-editor-bar.stuck {
+            box-shadow: 0 6px 12px rgba(15, 23, 42, 0.12);
+        }
+
+        .link-editor-input {
+            flex: 1;
+            min-width: 200px;
+            padding: 8px 10px;
+            border-radius: 6px;
+            border: 1px solid #d0d0ce;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        .link-editor-actions {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+
+        .link-editor-bar button {
+            border: 1px solid #d0d0ce;
+            background: #fafafa;
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-size: 13px;
+            cursor: pointer;
+            color: #494848;
+            transition: background 0.2s, border 0.2s, color 0.2s;
+        }
+
+        .link-editor-bar button:hover {
+            background: #ececec;
+            border-color: #c0c0bd;
+        }
+
+        .link-target-toggle[aria-pressed="true"] {
+            background: #2383e2;
+            color: #fff;
+            border-color: #2383e2;
+        }
+
+        .editor-content {
+            padding: 24px 32px 48px;
+        }
+
+        .ProseMirror {
+            min-height: 400px;
+            outline: none;
+        }
+
+        .ProseMirror p.is-editor-empty:first-child::before {
+            content: attr(data-placeholder);
+            float: left;
+            color: #adb5bd;
+            pointer-events: none;
+            height: 0;
+        }
+
+        .status-bar {
+            padding: 10px 24px;
+            font-size: 13px;
+            border-top: 1px solid #e9e9e7;
+            background: #fff;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .status-message {
+            color: #6b6b67;
+        }
+
+        .status-message.status-success {
+            color: #2f8f2f;
+        }
+
+        .status-message.status-error {
+            color: #c0352b;
+        }
+
+        .breadcrumb {
+            font-size: 12px;
+            color: #9b9a97;
+        }
+
+        .breadcrumb span + span::before {
+            content: ' / ';
+            color: #c6c5c1;
+        }
+
+        .empty-state {
+            padding: 40px;
+            text-align: center;
+            color: #9b9a97;
+        }
+
+        @media (max-width: 960px) {
+            .app-container {
+                flex-direction: column;
+            }
+
+            .sidebar {
+                width: 100%;
+                height: 260px;
+            }
+        }
+        .template-modal {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 2100;
+        }
+
+        .template-modal.visible {
+            display: flex;
+        }
+
+        .template-modal-backdrop {
+            position: absolute;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.25);
+        }
+
+        .template-modal-content {
+            position: relative;
+            background: #fff;
+            width: min(640px, calc(100vw - 40px));
+            max-height: calc(100vh - 80px);
+            border-radius: 12px;
+            box-shadow: 0 20px 45px rgba(15, 23, 42, 0.16);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .template-modal-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 20px 24px;
+            border-bottom: 1px solid #e6e6e4;
+        }
+
+        .template-modal-title {
+            font-size: 18px;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .template-modal-close {
+            border: none;
+            background: transparent;
+            cursor: pointer;
+            font-size: 20px;
+            line-height: 1;
+            color: #666;
+        }
+
+        .template-modal-body {
+            padding: 24px;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .template-list-view {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .template-create-button {
+            align-self: flex-start;
+        }
+
+        .template-items {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .template-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 16px;
+            border: 1px solid #dcdcdc;
+            border-radius: 8px;
+            background: #fafafa;
+            cursor: pointer;
+            transition: background 0.2s ease, border-color 0.2s ease;
+            font-size: 14px;
+            text-align: left;
+        }
+
+        .template-item:hover {
+            background: #f0f7ff;
+            border-color: #2383e2;
+        }
+
+        .template-empty-state,
+        .template-empty-elements {
+            padding: 16px;
+            border: 1px dashed #c2c2bf;
+            border-radius: 8px;
+            font-size: 13px;
+            color: #666;
+            white-space: pre-line;
+        }
+
+        .template-creator-view form {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .template-element-list {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .template-preview-panel {
+            border: 1px solid #dfe1e5;
+            border-radius: 12px;
+            padding: 16px;
+            background: #fcfcfb;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .template-preview-title {
+            margin: 0;
+            font-size: 14px;
+            font-weight: 600;
+            color: #343a40;
+        }
+
+        .template-preview-canvas {
+            border: 1px dashed #ced4da;
+            border-radius: 10px;
+            padding: 16px;
+            min-height: 160px;
+            background: #fff;
+            overflow: auto;
+        }
+
+        .template-preview-stage {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .template-preview-empty {
+            color: #adb5bd;
+            font-size: 13px;
+            text-align: center;
+            padding: 24px 0;
+        }
+
+        .template-creator-view label {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 13px;
+            color: #444;
+        }
+
+        .template-creator-view input,
+        .template-creator-view textarea,
+        .template-creator-view select {
+            padding: 8px 10px;
+            border-radius: 6px;
+            border: 1px solid #cfcfcb;
+            font-size: 13px;
+        }
+
+        .template-element-editor {
+            border: 1px solid #dfe1e5;
+            border-radius: 10px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            background: #fdfdfc;
+        }
+
+        .template-element-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .template-element-type {
+            flex: 1;
+        }
+
+        .template-element-remove {
+            border: none;
+            background: #f2f2f0;
+            color: #a33a3a;
+            padding: 6px 10px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 12px;
+        }
+
+        .template-element-remove:hover {
+            background: #f8dede;
+        }
+
+        .template-element-controls {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 12px;
+        }
+
+        .template-element-children {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .template-add-child,
+        .template-add-element,
+        .template-creator-actions button,
+        .template-create-button {
+            border: none;
+            border-radius: 8px;
+            padding: 10px 16px;
+            cursor: pointer;
+            background: #2383e2;
+            color: #fff;
+            font-size: 13px;
+            align-self: flex-start;
+        }
+
+        .template-add-child:hover,
+        .template-add-element:hover,
+        .template-creator-actions button:hover,
+        .template-create-button:hover {
+            background: #1b6cc4;
+        }
+
+        .template-creator-actions {
+            display: flex;
+            gap: 12px;
+        }
+
+        .template-cancel-button {
+            background: #f2f2f0;
+            color: #444;
+        }
+
+        .template-cancel-button:hover {
+            background: #e4e4e1;
+        }
+
+        .template-modal-footer {
+            padding: 0 24px 24px;
+        }
+    </style>
+</head>
+<body>
+    <div class="app-container">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div class="sidebar-title">ページ一覧</div>
+            </div>
+            <div class="sidebar-actions">
+                <button id="create-root-page" class="btn">新規ページ</button>
+                <button id="reload-pages" class="btn">再読み込み</button>
+            </div>
+            <div id="page-tree" class="page-tree"></div>
+        </aside>
+        <main class="main-area">
+            <div class="page-header">
+                <div class="breadcrumb" id="breadcrumb"></div>
+                <div class="page-header-row">
+                    <div class="input-group">
+                        <label class="input-label" for="page-name">Page ID</label>
+                        <input id="page-name" class="text-input" placeholder="sample-page" />
+                    </div>
+                    <div class="input-group" style="flex:1; min-width: 260px;">
+                        <label class="input-label" for="page-title">ページタイトル（表示）</label>
+                        <input id="page-title" class="text-input" placeholder="ページタイトル" />
+                    </div>
+                    <div class="header-actions">
+                        <button id="add-child-page" class="btn" type="button">子ページを追加</button>
+                        <button id="save-page" class="btn btn-primary" type="button">保存</button>
+                        <button id="view-page" class="btn" type="button">ページを表示</button>
+                    </div>
+                </div>
+                <div class="toolbar" id="toolbar"></div>
+            </div>
+            <div class="editor-wrapper">
+                <div class="editor-container">
+                    <div class="link-editor-bar" id="link-editor-bar">
+                        <input id="link-editor-input" class="link-editor-input" type="text" placeholder="https://example.com" aria-label="リンク先URL" />
+                        <div class="link-editor-actions">
+                            <button id="link-target-toggle" class="link-target-toggle" type="button" aria-pressed="false" title="新しいタブで開く" aria-label="新しいタブで開く">
+                                ↗
+                            </button>
+                            <button id="link-apply" type="button" title="リンクを適用">適用</button>
+                            <button id="link-remove" type="button" title="リンクを解除">解除</button>
+                            <button id="link-cancel" type="button" title="リンク編集を閉じる">閉じる</button>
+                        </div>
+                    </div>
+                    <div id="youtube-paste-popup" class="youtube-paste-popup" role="dialog" aria-hidden="true">
+                        <div class="youtube-paste-popup-message">YouTubeのURLが検出されました。どのように貼り付けますか？</div>
+                        <div class="youtube-paste-popup-actions">
+                            <button id="youtube-paste-as-url" class="btn" type="button">URLを貼り付け</button>
+                            <button id="youtube-embed-video" class="btn btn-primary" type="button">動画を埋め込む</button>
+                        </div>
+                    </div>
+                    <div id="template-modal" class="template-modal" aria-hidden="true">
+                        <div id="template-modal-backdrop" class="template-modal-backdrop" role="presentation"></div>
+                        <div class="template-modal-content" role="dialog" aria-modal="true" aria-labelledby="template-modal-title">
+                            <div class="template-modal-header">
+                                <h2 id="template-modal-title" class="template-modal-title">テンプレート</h2>
+                                <button id="template-modal-close" class="template-modal-close" type="button" aria-label="閉じる">×</button>
+                            </div>
+                            <div class="template-modal-body">
+                                <div id="template-list-view" class="template-list-view">
+                                    <button id="template-create-button" class="template-create-button" type="button">テンプレート作成</button>
+                                    <div id="template-items" class="template-items"></div>
+                                </div>
+                                <div id="template-creator-view" class="template-creator-view" hidden>
+                                    <form id="template-form">
+                                        <label for="template-name">テンプレート名
+                                            <input id="template-name" type="text" placeholder="テンプレート名を入力" autocomplete="off" />
+                                        </label>
+                                        <div id="template-element-list" class="template-element-list"></div>
+                                        <button id="template-add-element" class="template-add-element" type="button">要素を追加</button>
+                                        <div class="template-preview-panel">
+                                            <h3 class="template-preview-title">プレビュー</h3>
+                                            <div id="template-preview" class="template-preview-canvas"></div>
+                                        </div>
+                                        <div class="template-creator-actions">
+                                            <button id="template-save" type="submit">テンプレートを保存</button>
+                                            <button id="template-cancel" class="template-cancel-button" type="button">キャンセル</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="editor-content">
+                        <div id="editor" class="editor"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="status-bar">
+                <div id="status-message" class="status-message"></div>
+                <div id="updated-at" class="status-message"></div>
+            </div>
+        </main>
+        <div id="loading-overlay" class="loading-overlay" aria-live="polite" aria-busy="true" role="status">
+            <div class="loading-popup">
+                <div class="loading-spinner" aria-hidden="true"></div>
+                <div id="loading-message" class="loading-message">読み込み中...</div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { Editor, Node, mergeAttributes } from 'https://esm.sh/@tiptap/core';
+        import { StarterKit } from 'https://esm.sh/@tiptap/starter-kit';
+        import { Link } from 'https://esm.sh/@tiptap/extension-link';
+        import { Placeholder } from 'https://esm.sh/@tiptap/extension-placeholder';
+        import { Table } from 'https://esm.sh/@tiptap/extension-table';
+        import { TableRow } from 'https://esm.sh/@tiptap/extension-table-row';
+        import { TableCell } from 'https://esm.sh/@tiptap/extension-table-cell';
+        import { TableHeader } from 'https://esm.sh/@tiptap/extension-table-header';
+        import { NodeSelection } from 'https://esm.sh/@tiptap/pm/state';
+        import { ResizableImage } from 'https://brahmoon.github.io/wiki/extensions/resizableImage/ResizableImage.js';
+        import { DriveImageExtension } from 'https://brahmoon.github.io/wiki/extensions/driveImage/DriveImageExtension.js';
+        import { TemplateManager, UITemplateExtension } from './extensions/ui-template.js';
+        import { WikiDataService } from './scripts/wikiDataService.js';
+
+        const YouTubeEmbed = Node.create({
+            name: 'youtube',
+            group: 'block',
+            atom: true,
+            draggable: true,
+            selectable: true,
+            isolating: true,
+            addOptions() {
+                return {
+                    HTMLAttributes: {
+                        class: 'youtube-embed',
+                        frameborder: '0',
+                        allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
+                        allowfullscreen: 'true',
+                        title: 'YouTube video player'
+                    }
+                };
+            },
+            addAttributes() {
+                return {
+                    src: {
+                        default: null
+                    },
+                    videoId: {
+                        default: null
+                    },
+                    start: {
+                        default: null
+                    }
+                };
+            },
+            parseHTML() {
+                return [
+                    {
+                        tag: 'iframe[src*="youtube.com/embed"]',
+                        getAttrs: dom => {
+                            if (!(dom instanceof HTMLElement)) {
+                                return false;
+                            }
+                            const src = dom.getAttribute('src') || '';
+                            const dataVideoId = dom.getAttribute('data-video-id');
+                            const dataStart = dom.getAttribute('data-start');
+                            let videoId = dataVideoId || null;
+                            let start = null;
+                            if (dataStart !== null && dataStart !== '') {
+                                const parsedStart = Number(dataStart);
+                                if (Number.isFinite(parsedStart) && parsedStart > 0) {
+                                    start = parsedStart;
+                                }
+                            }
+                            if (!videoId) {
+                                const extracted = extractYouTubeDataFromEmbedSrc(src);
+                                videoId = extracted.videoId;
+                                if (!start && extracted.startSeconds > 0) {
+                                    start = extracted.startSeconds;
+                                }
+                            }
+                            if (!videoId) {
+                                return false;
+                            }
+                            return {
+                                src,
+                                videoId,
+                                start
+                            };
+                        }
+                    }
+                ];
+            },
+            renderHTML({ HTMLAttributes }) {
+                const attrs = { ...HTMLAttributes };
+                const videoId = attrs.videoId || null;
+                const start = attrs.start ?? null;
+                if (videoId) {
+                    const startSeconds = typeof start === 'number' ? start : Number(start) || 0;
+                    attrs.src = createYouTubeEmbedSrc(videoId, startSeconds);
+                }
+                const dataAttrs = {
+                    'data-video-id': videoId || undefined,
+                    'data-start': start != null && start !== '' ? (typeof start === 'number' ? start : Number(start) || undefined) : undefined
+                };
+                delete attrs.videoId;
+                delete attrs.start;
+                if (dataAttrs['data-start'] === undefined) {
+                    delete dataAttrs['data-start'];
+                }
+                return ['iframe', mergeAttributes(this.options.HTMLAttributes, attrs, dataAttrs)];
+            },
+            addCommands() {
+                return {
+                    insertYouTube:
+                        options =>
+                        ({ chain }) => {
+                            if (!options?.videoId) {
+                                return false;
+                            }
+                            const startSeconds = options.start && options.start > 0 ? Math.floor(options.start) : 0;
+                            return chain()
+                                .insertContent({
+                                    type: this.name,
+                                    attrs: {
+                                        videoId: options.videoId,
+                                        start: startSeconds > 0 ? startSeconds : null,
+                                        src: createYouTubeEmbedSrc(options.videoId, startSeconds)
+                                    }
+                                })
+                                .run();
+                        }
+                };
+            }
+        });
+
+        /**
+         * Apps Script endpoints
+         * - wiki-backend.gs (spreadsheet storage)
+         * - extensions/driveImage/DriveImageAppsScript.gs (Drive image management)
+         */
+        const WIKI_APPS_SCRIPT_ENDPOINT = 'https://script.google.com/macros/s/AKfycbyFiFm2zdtkPhuZ4EOJ-yLEGnw_opM5hxQBb7EE-sSg2mJ9pOU3HTrFoAXgIeb5J2Q91w/exec';
+        const DRIVE_IMAGE_APPS_SCRIPT_ENDPOINT = 'https://script.google.com/macros/s/AKfycbytAAym-sjES9hdBK_0LES7nQ6H4mwxCgADk7u9xY--YRIWlkEJrvK2FMHmJG74zQ7E/exec';
+
+        const APPS_SCRIPT_ENDPOINT = WIKI_APPS_SCRIPT_ENDPOINT;
+
+        window.APP_ENDPOINTS = {
+          wiki: WIKI_APPS_SCRIPT_ENDPOINT,
+          driveImage: DRIVE_IMAGE_APPS_SCRIPT_ENDPOINT
+        };
+
+        const dataService = new WikiDataService({ endpoint: APPS_SCRIPT_ENDPOINT });
+
+        const state = {
+            editor: null,
+            isDirty: false,
+            pageTree: [],
+            pageMap: new Map(),
+            currentPageId: null,
+            currentParentId: null,
+            isNewPage: false,
+            isApplyingContent: false,
+            linkEditor: {
+                visible: false,
+                openInNewTab: false
+            },
+            youtubePaste: {
+                visible: false,
+                url: '',
+                from: null,
+                to: null,
+                videoId: null,
+                startSeconds: 0
+            },
+            templateManager: null
+        };
+
+        const elements = {
+            pageTree: document.getElementById('page-tree'),
+            breadcrumb: document.getElementById('breadcrumb'),
+            pageName: document.getElementById('page-name'),
+            pageTitle: document.getElementById('page-title'),
+            addChildPage: document.getElementById('add-child-page'),
+            savePage: document.getElementById('save-page'),
+            viewPage: document.getElementById('view-page'),
+            createRootPage: document.getElementById('create-root-page'),
+            reloadPages: document.getElementById('reload-pages'),
+            toolbar: document.getElementById('toolbar'),
+            pageHeader: document.querySelector('.page-header'),
+            editorWrapper: document.querySelector('.editor-wrapper'),
+            editorContainer: document.querySelector('.editor-container'),
+            editor: document.getElementById('editor'),
+            statusMessage: document.getElementById('status-message'),
+            updatedAt: document.getElementById('updated-at'),
+            loadingOverlay: document.getElementById('loading-overlay'),
+            loadingMessage: document.getElementById('loading-message'),
+            linkEditorBar: document.getElementById('link-editor-bar'),
+            linkInput: document.getElementById('link-editor-input'),
+            linkTargetToggle: document.getElementById('link-target-toggle'),
+            linkApply: document.getElementById('link-apply'),
+            linkRemove: document.getElementById('link-remove'),
+            linkCancel: document.getElementById('link-cancel'),
+            youtubePastePopup: document.getElementById('youtube-paste-popup'),
+            youtubePasteAsUrl: document.getElementById('youtube-paste-as-url'),
+            youtubeEmbedVideo: document.getElementById('youtube-embed-video'),
+            templateModal: document.getElementById('template-modal'),
+            templateModalBackdrop: document.getElementById('template-modal-backdrop'),
+            templateModalClose: document.getElementById('template-modal-close'),
+            templateListView: document.getElementById('template-list-view'),
+            templateItems: document.getElementById('template-items'),
+            templateCreateButton: document.getElementById('template-create-button'),
+            templateCreatorView: document.getElementById('template-creator-view'),
+            templateForm: document.getElementById('template-form'),
+            templateNameInput: document.getElementById('template-name'),
+            templateElementList: document.getElementById('template-element-list'),
+            templateAddElement: document.getElementById('template-add-element'),
+            templateCancel: document.getElementById('template-cancel'),
+            templatePreview: document.getElementById('template-preview')
+        };
+
+        hideLinkEditor();
+        hideYouTubePastePopup();
+
+        const loadingState = {
+            count: 0
+        };
+
+        const dragState = {
+            sourceId: null,
+            dropTargetId: null,
+            dropPosition: null
+        };
+
+        function beginLoading(message) {
+            loadingState.count += 1;
+            if (message) {
+                elements.loadingMessage.textContent = message;
+            }
+            elements.loadingOverlay.classList.add('visible');
+        }
+
+        function endLoading() {
+            loadingState.count = Math.max(loadingState.count - 1, 0);
+            if (loadingState.count === 0) {
+                elements.loadingOverlay.classList.remove('visible');
+            }
+        }
+
+        function updateToolbarMetrics() {
+            if (!elements.editorWrapper || !elements.pageHeader) {
+                return;
+            }
+            const height = elements.pageHeader.offsetHeight || 0;
+            elements.editorWrapper.style.setProperty('--page-header-height', `${height}px`);
+        }
+
+        function updateToolbarShadow() {
+            if (!elements.editorWrapper || !elements.pageHeader) {
+                return;
+            }
+            const scrolled = elements.editorWrapper.scrollTop > 4;
+            elements.pageHeader.classList.toggle('is-scrolled', scrolled);
+            if (elements.linkEditorBar) {
+                const shouldStick = elements.linkEditorBar.classList.contains('visible') && scrolled;
+                elements.linkEditorBar.classList.toggle('stuck', shouldStick);
+            }
+        }
+
+        function refreshToolbarAffordances() {
+            updateToolbarMetrics();
+            updateToolbarShadow();
+        }
+
+        function parseYouTubeTime(value) {
+            if (!value) {
+                return 0;
+            }
+            const stringValue = String(value).trim();
+            if (!stringValue) {
+                return 0;
+            }
+            if (/^\d+$/.test(stringValue)) {
+                return Math.max(parseInt(stringValue, 10), 0);
+            }
+            let total = 0;
+            let matched = false;
+            const timePattern = /(\d+)([hms])/gi;
+            let match;
+            while ((match = timePattern.exec(stringValue)) !== null) {
+                matched = true;
+                const amount = parseInt(match[1], 10);
+                const unit = match[2].toLowerCase();
+                if (unit === 'h') {
+                    total += amount * 3600;
+                } else if (unit === 'm') {
+                    total += amount * 60;
+                } else if (unit === 's') {
+                    total += amount;
+                }
+            }
+            if (matched) {
+                return total;
+            }
+            if (stringValue.includes(':')) {
+                const parts = stringValue.split(':').map(part => part.trim());
+                if (parts.every(part => /^\d+$/.test(part))) {
+                    let multiplier = 1;
+                    for (let index = parts.length - 1; index >= 0; index -= 1) {
+                        total += parseInt(parts[index], 10) * multiplier;
+                        multiplier *= 60;
+                    }
+                    return total;
+                }
+            }
+            return 0;
+        }
+
+        function createYouTubeEmbedSrc(videoId, startSeconds = 0) {
+            const normalizedId = (videoId || '').trim().replace(/[^a-zA-Z0-9_-]/g, '');
+            if (!normalizedId) {
+                return '';
+            }
+            const url = new URL(`https://www.youtube.com/embed/${normalizedId}`);
+            const seconds = Number.isFinite(startSeconds) ? Math.max(Math.floor(startSeconds), 0) : 0;
+            if (seconds > 0) {
+                url.searchParams.set('start', String(seconds));
+            }
+            url.searchParams.set('rel', '0');
+            url.searchParams.set('modestbranding', '1');
+            return url.toString();
+        }
+
+        function parseYouTubeUrl(rawUrl) {
+            if (!rawUrl) {
+                return null;
+            }
+            const trimmed = rawUrl.trim();
+            if (!trimmed) {
+                return null;
+            }
+            const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+            let url;
+            try {
+                url = new URL(normalized);
+            } catch (error) {
+                return null;
+            }
+            const hostname = url.hostname.replace(/^www\./i, '').toLowerCase();
+            let videoId = null;
+            if (hostname === 'youtu.be') {
+                const segments = url.pathname.split('/').filter(Boolean);
+                videoId = segments[segments.length - 1] || null;
+            } else if (hostname === 'youtube.com' || hostname.endsWith('.youtube.com') || hostname === 'youtube-nocookie.com') {
+                const path = url.pathname.replace(/\/+$/, '');
+                if (path === '/watch') {
+                    videoId = url.searchParams.get('v');
+                } else if (path.startsWith('/shorts/')) {
+                    const segments = path.split('/').filter(Boolean);
+                    videoId = segments[segments.length - 1] || null;
+                } else if (path.startsWith('/embed/')) {
+                    const segments = path.split('/').filter(Boolean);
+                    videoId = segments[segments.length - 1] || null;
+                } else if (path.startsWith('/live/')) {
+                    const segments = path.split('/').filter(Boolean);
+                    videoId = segments[segments.length - 1] || null;
+                }
+                if (!videoId) {
+                    videoId = url.searchParams.get('v');
+                }
+            }
+            if (!videoId) {
+                return null;
+            }
+            const normalizedId = videoId.replace(/[^a-zA-Z0-9_-]/g, '');
+            if (!normalizedId) {
+                return null;
+            }
+            const startParam = url.searchParams.get('t') || url.searchParams.get('start');
+            const startSeconds = parseYouTubeTime(startParam);
+            return {
+                rawUrl: trimmed,
+                normalizedUrl: url.toString(),
+                videoId: normalizedId,
+                startSeconds
+            };
+        }
+
+        function extractYouTubeDataFromEmbedSrc(src) {
+            if (!src) {
+                return { videoId: null, startSeconds: 0 };
+            }
+            let url;
+            try {
+                url = new URL(src, 'https://www.youtube.com');
+            } catch (error) {
+                return { videoId: null, startSeconds: 0 };
+            }
+            const segments = url.pathname.split('/').filter(Boolean);
+            let videoId = null;
+            if (segments.length >= 2 && segments[0] === 'embed') {
+                videoId = segments[1] || null;
+            }
+            const startSeconds = parseYouTubeTime(url.searchParams.get('start'));
+            return {
+                videoId: videoId ? videoId.replace(/[^a-zA-Z0-9_-]/g, '') : null,
+                startSeconds
+            };
+        }
+
+        function hideYouTubePastePopup() {
+            state.youtubePaste.visible = false;
+            state.youtubePaste.url = '';
+            state.youtubePaste.from = null;
+            state.youtubePaste.to = null;
+            state.youtubePaste.videoId = null;
+            state.youtubePaste.startSeconds = 0;
+            if (elements.youtubePastePopup) {
+                elements.youtubePastePopup.classList.remove('visible');
+                elements.youtubePastePopup.setAttribute('aria-hidden', 'true');
+                elements.youtubePastePopup.style.visibility = '';
+                elements.youtubePastePopup.style.left = '';
+                elements.youtubePastePopup.style.top = '';
+            }
+        }
+
+        function positionYouTubePastePopup(from) {
+            if (!elements.youtubePastePopup || !state.editor) {
+                return;
+            }
+            const view = state.editor.view;
+            let coords;
+            try {
+                coords = view.coordsAtPos(Math.max(from, 0));
+            } catch (error) {
+                return;
+            }
+            const containerRect = elements.editorContainer?.getBoundingClientRect();
+            const popup = elements.youtubePastePopup;
+            if (!containerRect) {
+                return;
+            }
+            popup.classList.add('visible');
+            popup.setAttribute('aria-hidden', 'false');
+            popup.style.visibility = 'hidden';
+            popup.style.left = '0px';
+            popup.style.top = '0px';
+            requestAnimationFrame(() => {
+                const popupRect = popup.getBoundingClientRect();
+                const left = coords.left - containerRect.left - popupRect.width / 2;
+                const top = coords.bottom - containerRect.top + 12;
+                const maxLeft = containerRect.width - popupRect.width - 16;
+                const clampedLeft = Math.min(Math.max(left, 16), Math.max(maxLeft, 16));
+                const maxTop = containerRect.height - popupRect.height - 16;
+                const clampedTop = Math.min(Math.max(top, 16), Math.max(maxTop, 16));
+                popup.style.left = `${clampedLeft}px`;
+                popup.style.top = `${clampedTop}px`;
+                popup.style.visibility = 'visible';
+                elements.youtubeEmbedVideo?.focus();
+            });
+        }
+
+        function showYouTubePastePopup(pasteInfo) {
+            if (!pasteInfo || !elements.youtubePastePopup) {
+                return;
+            }
+            state.youtubePaste.visible = true;
+            state.youtubePaste.url = pasteInfo.rawUrl;
+            state.youtubePaste.from = pasteInfo.from;
+            state.youtubePaste.to = pasteInfo.to;
+            state.youtubePaste.videoId = pasteInfo.videoId;
+            state.youtubePaste.startSeconds = pasteInfo.startSeconds;
+            positionYouTubePastePopup(pasteInfo.to ?? pasteInfo.from ?? state.editor?.state.selection.to ?? 0);
+        }
+
+        function applyYouTubePasteAsUrl() {
+            const editor = state.editor;
+            if (!editor || !state.youtubePaste.url) {
+                hideYouTubePastePopup();
+                return;
+            }
+            const { from, to, url } = {
+                from: state.youtubePaste.from ?? editor.state.selection.from,
+                to: state.youtubePaste.to ?? editor.state.selection.to,
+                url: state.youtubePaste.url
+            };
+            hideYouTubePastePopup();
+            //editor.chain().focus().insertContentAt({ from, to }, url).run();
+        }
+
+        function applyYouTubeEmbed() {
+            const editor = state.editor;
+            if (!editor || !state.youtubePaste.videoId) {
+                hideYouTubePastePopup();
+                return;
+            }
+            const from = state.youtubePaste.from ?? editor.state.selection.from;
+            const to = state.youtubePaste.to ?? editor.state.selection.to;
+            const videoId = state.youtubePaste.videoId;
+            const startSeconds = state.youtubePaste.startSeconds || 0;
+            hideYouTubePastePopup();
+            const embedSrc = createYouTubeEmbedSrc(videoId, startSeconds);
+            editor.chain().focus().insertContentAt({ from, to }, {
+                type: 'youtube',
+                attrs: {
+                    videoId,
+                    start: startSeconds > 0 ? startSeconds : null,
+                    src: embedSrc
+                }
+            }).run();
+        }
+
+        function handleEditorPaste(event) {
+            const editor = state.editor;
+            if (!editor) {
+                return;
+            }
+            const text = event.clipboardData?.getData('text/plain') || '';
+            const pasteData = parseYouTubeUrl(text);
+            if (!pasteData) {
+                hideYouTubePastePopup();
+                return;
+            }
+            event.preventDefault();
+            const { from, to } = editor.state.selection;
+            pasteData.from = from;
+            pasteData.to = to;
+            showYouTubePastePopup(pasteData);
+        }
+
+        function normalizeSlug(value) {
+            return value.trim().replace(/\s+/g, '-');
+        }
+
+        function isSlugTaken(parentId, slug, excludeId = null) {
+            if (!slug) {
+                return false;
+            }
+            const normalizedParent = parentId || null;
+            for (const node of state.pageMap.values()) {
+                if (excludeId && node.id === excludeId) {
+                    continue;
+                }
+                if (node.parentId === normalizedParent && node.slug === slug) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function generateUniqueSlug(parentId, baseSlug, excludeId = null) {
+            const normalizedBase = normalizeSlug(baseSlug || '');
+            const candidateBase = normalizedBase || 'page';
+            let candidate = candidateBase;
+            let index = 2;
+            while (isSlugTaken(parentId, candidate, excludeId)) {
+                candidate = `${candidateBase}${index}`;
+                index += 1;
+            }
+            return candidate;
+        }
+
+        function isDescendantId(id, potentialAncestor) {
+            if (!id || !potentialAncestor) {
+                return false;
+            }
+            return id === potentialAncestor || id.startsWith(`${potentialAncestor}/`);
+        }
+
+        function updateProvisionalPageId(slug) {
+            if (!state.isNewPage || !state.currentPageId) {
+                return;
+            }
+            const normalizedSlug = slug || '';
+            const parentId = state.currentParentId;
+            const newId = normalizedSlug
+                ? (parentId ? `${parentId}/${normalizedSlug}` : normalizedSlug)
+                : null;
+            const oldId = state.currentPageId;
+            if (!newId || newId === oldId) {
+                return;
+            }
+            if (isSlugTaken(parentId, normalizedSlug, oldId)) {
+                return;
+            }
+            const node = state.pageMap.get(oldId);
+            if (!node) {
+                return;
+            }
+            removeNode(oldId);
+            node.id = newId;
+            node.slug = normalizedSlug;
+            node.parentId = parentId || null;
+            insertNode(node);
+            state.currentPageId = newId;
+            renderTree();
+        }
+
+        function getPageIdFromQuery() {
+            const params = new URLSearchParams(window.location.search);
+            const value = (params.get('page') || '').trim();
+            return value || null;
+        }
+
+        function updateHistory(pageId) {
+            const url = pageId
+                ? `${window.location.pathname}?page=${encodeURIComponent(pageId)}`
+                : window.location.pathname;
+            history.replaceState({ pageId }, '', url);
+        }
+
+        function getParentId(id) {
+            if (!id) return null;
+            const parts = id.split('/');
+            parts.pop();
+            return parts.length ? parts.join('/') : null;
+        }
+
+        function getSlug(id) {
+            if (!id) return '';
+            const parts = id.split('/');
+            return parts.pop();
+        }
+
+        function updateBreadcrumb(id) {
+            elements.breadcrumb.innerHTML = '';
+            if (!id) return;
+            const fragments = id.split('/');
+            const parts = [];
+            for (let i = 0; i < fragments.length; i++) {
+                const segment = fragments.slice(0, i + 1).join('/');
+                parts.push({ id: segment, label: state.pageMap.get(segment)?.title || fragments[i] });
+            }
+            parts.forEach((part, index) => {
+                const span = document.createElement('span');
+                span.textContent = part.label || part.id;
+                span.dataset.id = part.id;
+                span.style.cursor = 'pointer';
+                span.addEventListener('click', () => {
+                    if (state.currentPageId === part.id) return;
+                    navigateToPage(part.id);
+                });
+                elements.breadcrumb.appendChild(span);
+            });
+        }
+
+        function isImageNodeSelection(editor) {
+            if (!editor) {
+                return false;
+            }
+            const selection = editor.state?.selection;
+            return selection instanceof NodeSelection && selection.node?.type?.name === 'image';
+        }
+
+        function getSelectedImageAttributes(editor) {
+            if (!isImageNodeSelection(editor)) {
+                return null;
+            }
+            return editor.state.selection.node?.attrs || null;
+        }
+
+        function isLinkActive(editor) {
+            if (!editor) {
+                return false;
+            }
+            if (editor.isActive('link')) {
+                return true;
+            }
+            const imageAttrs = getSelectedImageAttributes(editor);
+            return !!imageAttrs?.href;
+        }
+
+        function createToolbarButton(label, command, isActive, tooltip) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.addEventListener('click', command);
+            if (tooltip) {
+                button.title = tooltip;
+            }
+            if (isActive && isActive()) {
+                button.classList.add('active');
+            }
+            return button;
+        }
+
+        function renderToolbar() {
+            elements.toolbar.innerHTML = '';
+            const editor = state.editor;
+            if (!editor) return;
+
+            const buttons = [
+                createToolbarButton('B', () => editor.chain().focus().toggleBold().run(), () => editor.isActive('bold'), '太字'),
+                createToolbarButton('I', () => editor.chain().focus().toggleItalic().run(), () => editor.isActive('italic'), '斜体'),
+                createToolbarButton('🔗', handleLinkButtonClick, () => isLinkActive(editor), 'リンクを挿入/編集'),
+                createToolbarButton('H1', () => editor.chain().focus().toggleHeading({ level: 1 }).run(), () => editor.isActive('heading', { level: 1 }), '見出し 1'),
+                createToolbarButton('H2', () => editor.chain().focus().toggleHeading({ level: 2 }).run(), () => editor.isActive('heading', { level: 2 }), '見出し 2'),
+                createToolbarButton('H3', () => editor.chain().focus().toggleHeading({ level: 3 }).run(), () => editor.isActive('heading', { level: 3 }), '見出し 3'),
+                createToolbarButton('UL', () => editor.chain().focus().toggleBulletList().run(), () => editor.isActive('bulletList'), '箇条書きリスト'),
+                createToolbarButton('OL', () => editor.chain().focus().toggleOrderedList().run(), () => editor.isActive('orderedList'), '番号付きリスト'),
+                createToolbarButton('""', () => editor.chain().focus().toggleBlockquote().run(), () => editor.isActive('blockquote'), '引用'),
+                createToolbarButton('コード', () => editor.chain().focus().toggleCodeBlock().run(), () => editor.isActive('codeBlock'), 'コードブロック'),
+                createToolbarButton('表', () => editor.chain().focus().insertTable({ rows: 3, cols: 3 }).run(), () => false, '表を挿入')
+            ];
+
+            const templateButton = createToolbarButton('🧩', () => editor.commands.openTemplateManager(), () => false, 'テンプレートを挿入/作成');
+            const driveImageButton = createToolbarButton('🖼️', () => editor.commands.openImageModal(), () => false, 'Drive画像を挿入');
+            buttons.push(templateButton);
+            buttons.push(driveImageButton);
+
+            buttons.forEach(button => elements.toolbar.appendChild(button));
+
+            if (state.linkEditor.visible) {
+                syncLinkEditorFromSelection();
+            }
+
+            requestAnimationFrame(refreshToolbarAffordances);
+        }
+
+        function updateLinkTargetToggle() {
+            const pressed = state.linkEditor.openInNewTab;
+            const label = pressed ? '新しいタブで開く（ON）' : '新しいタブで開く';
+            elements.linkTargetToggle.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+            elements.linkTargetToggle.title = label;
+            elements.linkTargetToggle.setAttribute('aria-label', label);
+        }
+
+        function showLinkEditor() {
+            state.linkEditor.visible = true;
+            elements.linkEditorBar.classList.add('visible');
+            updateLinkTargetToggle();
+            requestAnimationFrame(refreshToolbarAffordances);
+        }
+
+        function hideLinkEditor() {
+            state.linkEditor.visible = false;
+            elements.linkEditorBar.classList.remove('visible');
+            elements.linkInput.value = '';
+            state.linkEditor.openInNewTab = false;
+            updateLinkTargetToggle();
+            requestAnimationFrame(refreshToolbarAffordances);
+        }
+
+        function handleLinkButtonClick() {
+            const editor = state.editor;
+            if (!editor) return;
+            if (isImageNodeSelection(editor)) {
+                const attrs = getSelectedImageAttributes(editor) || {};
+                elements.linkInput.value = attrs.href || '';
+                state.linkEditor.openInNewTab = attrs.target === '_blank';
+                showLinkEditor();
+                requestAnimationFrame(() => elements.linkInput.focus());
+                return;
+            }
+            const attrs = editor.getAttributes('link') || {};
+            elements.linkInput.value = attrs.href || '';
+            state.linkEditor.openInNewTab = attrs.target === '_blank';
+            showLinkEditor();
+            requestAnimationFrame(() => elements.linkInput.focus());
+        }
+
+        function applyLinkFromEditor() {
+            const editor = state.editor;
+            if (!editor) return;
+            const href = (elements.linkInput.value || '').trim();
+            if (isImageNodeSelection(editor)) {
+                if (!href) {
+                    editor.chain().focus().updateAttributes('image', {
+                        href: null,
+                        target: null,
+                        rel: null
+                    }).run();
+                    hideLinkEditor();
+                    return;
+                }
+                const attributes = {
+                    href,
+                    target: state.linkEditor.openInNewTab ? '_blank' : null,
+                    rel: state.linkEditor.openInNewTab ? 'noopener noreferrer' : null
+                };
+                editor.chain().focus().updateAttributes('image', attributes).run();
+                hideLinkEditor();
+                return;
+            }
+            const chain = editor.chain().focus();
+            if (!href) {
+                chain.extendMarkRange('link').unsetLink().run();
+                hideLinkEditor();
+                return;
+            }
+            const attributes = { href };
+            if (state.linkEditor.openInNewTab) {
+                attributes.target = '_blank';
+                attributes.rel = 'noopener noreferrer';
+            } else {
+                attributes.target = null;
+                attributes.rel = null;
+            }
+            chain.extendMarkRange('link').setLink(attributes).run();
+            hideLinkEditor();
+        }
+
+        function removeLinkFromSelection() {
+            const editor = state.editor;
+            if (!editor) return;
+            if (isImageNodeSelection(editor)) {
+                editor.chain().focus().updateAttributes('image', {
+                    href: null,
+                    target: null,
+                    rel: null
+                }).run();
+                hideLinkEditor();
+                return;
+            }
+            editor.chain().focus().extendMarkRange('link').unsetLink().run();
+            hideLinkEditor();
+        }
+
+        function preventEditorLinkNavigation(event) {
+            const anchor = event.target.closest('a');
+            if (!anchor || !elements.editor?.contains(anchor)) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            state.editor?.commands.focus();
+        }
+
+        function syncLinkEditorFromSelection() {
+            if (!state.linkEditor.visible) {
+                return;
+            }
+            const editor = state.editor;
+            if (!editor) {
+                return;
+            }
+            if (isImageNodeSelection(editor)) {
+                const attrs = getSelectedImageAttributes(editor) || {};
+                elements.linkInput.value = attrs.href || '';
+                state.linkEditor.openInNewTab = attrs.target === '_blank';
+                updateLinkTargetToggle();
+                return;
+            }
+            const attrs = editor.getAttributes('link') || {};
+            if (attrs.href) {
+                elements.linkInput.value = attrs.href;
+                state.linkEditor.openInNewTab = attrs.target === '_blank';
+                updateLinkTargetToggle();
+            }
+        }
+
+        function buildPageTree(pages) {
+            const nodes = [];
+            pages.forEach((page, index) => {
+                if (!page.id) {
+                    return;
+                }
+                const parentId = getParentId(page.id);
+                const parsedOrder = Number(page.order);
+                nodes.push({
+                    id: page.id,
+                    title: page.title || '無題',
+                    updatedAt: page.updatedAt || '',
+                    parentId,
+                    slug: getSlug(page.id),
+                    order: Number.isFinite(parsedOrder) ? parsedOrder : index + 1,
+                    children: []
+                });
+            });
+
+            const map = new Map();
+            nodes.forEach(node => map.set(node.id, node));
+
+            const buckets = new Map();
+            nodes.forEach(node => {
+                const parentExists = node.parentId && map.has(node.parentId);
+                const key = parentExists ? node.parentId : null;
+                if (!parentExists) {
+                    node.parentId = null;
+                }
+                if (!buckets.has(key)) {
+                    buckets.set(key, []);
+                }
+                buckets.get(key).push(node);
+            });
+
+            const sortNodes = list => {
+                list.sort((a, b) => {
+                    const orderA = Number.isFinite(a.order) ? a.order : Number.MAX_SAFE_INTEGER;
+                    const orderB = Number.isFinite(b.order) ? b.order : Number.MAX_SAFE_INTEGER;
+                    if (orderA !== orderB) {
+                        return orderA - orderB;
+                    }
+                    return (a.title || '').localeCompare(b.title || '', 'ja');
+                });
+            };
+
+            const roots = [];
+            const buildChildren = parentId => {
+                const key = parentId || null;
+                const list = buckets.get(key) || [];
+                sortNodes(list);
+                list.forEach(child => {
+                    if (parentId) {
+                        const parentNode = map.get(parentId);
+                        if (parentNode) {
+                            parentNode.children.push(child);
+                        }
+                    } else {
+                        roots.push(child);
+                    }
+                    buildChildren(child.id);
+                });
+            };
+
+            buildChildren(null);
+
+            state.pageMap = map;
+            state.pageTree = roots;
+        }
+
+        function getSiblingList(parentId) {
+            if (parentId && state.pageMap.has(parentId)) {
+                return state.pageMap.get(parentId).children;
+            }
+            return state.pageTree;
+        }
+
+        function sortSiblings(siblings) {
+            siblings.sort((a, b) => {
+                const orderA = Number.isFinite(a.order) ? a.order : Number.MAX_SAFE_INTEGER;
+                const orderB = Number.isFinite(b.order) ? b.order : Number.MAX_SAFE_INTEGER;
+                if (orderA !== orderB) {
+                    return orderA - orderB;
+                }
+                return (a.title || '').localeCompare(b.title || '', 'ja');
+            });
+        }
+
+        function insertNode(node) {
+            const parentId = node.parentId || null;
+            const siblings = getSiblingList(parentId);
+            if (!Number.isFinite(Number(node.order))) {
+                const maxOrder = siblings.reduce((max, child) => {
+                    if (Number.isFinite(child.order) && child.order > max) {
+                        return child.order;
+                    }
+                    return max;
+                }, 0);
+                node.order = maxOrder + 1;
+            }
+            siblings.push(node);
+            sortSiblings(siblings);
+            state.pageMap.set(node.id, node);
+        }
+
+        function removeNode(id) {
+            const node = state.pageMap.get(id);
+            if (!node) {
+                return;
+            }
+            const parentId = node.parentId || null;
+            const siblings = getSiblingList(parentId);
+            const index = siblings.findIndex(child => child.id === id);
+            if (index >= 0) {
+                siblings.splice(index, 1);
+            }
+            state.pageMap.delete(id);
+        }
+
+        function createTreeList(parentId) {
+            const list = document.createElement('ul');
+            list.className = parentId ? 'tree-children' : 'tree-list';
+            list.dataset.parentId = parentId || '';
+            list.addEventListener('dragover', handleListDragOver);
+            list.addEventListener('dragleave', handleListDragLeave);
+            list.addEventListener('drop', handleListDrop);
+            return list;
+        }
+
+        function createDropZoneItem(parentId, referenceId, position) {
+            const zone = document.createElement('li');
+            zone.className = 'tree-drop-zone';
+            zone.dataset.parentId = parentId || '';
+            if (referenceId) {
+                zone.dataset.referenceId = referenceId;
+            } else {
+                delete zone.dataset.referenceId;
+            }
+            zone.dataset.position = position;
+            zone.addEventListener('dragover', handleDropZoneDragOver);
+            zone.addEventListener('dragleave', handleDropZoneDragLeave);
+            zone.addEventListener('drop', handleDropZoneDrop);
+            return zone;
+        }
+
+        function handleListDragOver(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const parentId = event.currentTarget.dataset.parentId || '';
+            if (parentId && isDescendantId(parentId, dragState.sourceId)) {
+                return;
+            }
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            event.currentTarget.classList.add('drop-target');
+            dragState.dropTargetId = null;
+            dragState.dropPosition = null;
+        }
+
+        function handleListDragLeave(event) {
+            event.currentTarget.classList.remove('drop-target');
+        }
+
+        function handleListDrop(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const parentId = event.currentTarget.dataset.parentId || '';
+            event.currentTarget.classList.remove('drop-target');
+            if (parentId && isDescendantId(parentId, dragState.sourceId)) {
+                setStatus('子ページの下へは移動できません。', 'error');
+                return;
+            }
+            dragState.dropTargetId = null;
+            dragState.dropPosition = null;
+            movePage(dragState.sourceId, parentId ? parentId : null);
+        }
+
+        function handleDragStart(event) {
+            const id = event.currentTarget.dataset.id;
+            if (!id) {
+                return;
+            }
+            dragState.sourceId = id;
+            event.dataTransfer.setData('text/plain', id);
+            event.dataTransfer.effectAllowed = 'move';
+            event.currentTarget.classList.add('dragging');
+        }
+
+        function handleDragEnd(event) {
+            event.currentTarget.classList.remove('dragging');
+            dragState.sourceId = null;
+            dragState.dropTargetId = null;
+            dragState.dropPosition = null;
+            clearDropIndicators();
+        }
+
+        function setItemDropIndicator(element, position) {
+            if (!element) {
+                return;
+            }
+            element.classList.remove('drop-target', 'drop-before', 'drop-after', 'drop-inside');
+            if (!position) {
+                return;
+            }
+            if (position === 'inside') {
+                element.classList.add('drop-target');
+                element.classList.add('drop-inside');
+            } else if (position === 'before') {
+                element.classList.add('drop-before');
+            } else if (position === 'after') {
+                element.classList.add('drop-after');
+            }
+        }
+
+        function handleItemDragEnter(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const targetId = event.currentTarget.dataset.id;
+            if (!targetId || targetId === dragState.sourceId || isDescendantId(targetId, dragState.sourceId)) {
+                return;
+            }
+            dragState.dropTargetId = targetId;
+        }
+
+        function handleItemDragLeave(event) {
+            setItemDropIndicator(event.currentTarget, null);
+            if (event.currentTarget.dataset.id === dragState.dropTargetId) {
+                dragState.dropTargetId = null;
+                dragState.dropPosition = null;
+            }
+        }
+
+        function handleItemDragOver(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const targetId = event.currentTarget.dataset.id;
+            if (!targetId || targetId === dragState.sourceId || isDescendantId(targetId, dragState.sourceId)) {
+                return;
+            }
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            const rect = event.currentTarget.getBoundingClientRect();
+            const offsetY = event.clientY - rect.top;
+            const threshold = rect.height * 0.25;
+            let position = 'inside';
+            if (rect.height > 0) {
+                if (offsetY < threshold) {
+                    position = 'before';
+                } else if (offsetY > rect.height - threshold) {
+                    position = 'after';
+                }
+            }
+            dragState.dropTargetId = targetId;
+            dragState.dropPosition = position;
+            setItemDropIndicator(event.currentTarget, position);
+        }
+
+        function handleItemDrop(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const targetId = event.currentTarget.dataset.id;
+            const dropPosition = dragState.dropPosition || 'inside';
+            setItemDropIndicator(event.currentTarget, null);
+            if (!targetId || targetId === dragState.sourceId || isDescendantId(targetId, dragState.sourceId)) {
+                dragState.dropTargetId = null;
+                dragState.dropPosition = null;
+                return;
+            }
+            if (dropPosition === 'before' || dropPosition === 'after') {
+                movePageRelative(dragState.sourceId, targetId, dropPosition);
+            } else {
+                movePage(dragState.sourceId, targetId);
+            }
+            dragState.dropTargetId = null;
+            dragState.dropPosition = null;
+        }
+
+        function clearDropIndicators() {
+            document.querySelectorAll('.drop-target, .drop-before, .drop-after, .drop-inside')
+                .forEach(el => el.classList.remove('drop-target', 'drop-before', 'drop-after', 'drop-inside'));
+            document.querySelectorAll('.tree-drop-zone.active')
+                .forEach(el => el.classList.remove('active'));
+            dragState.dropTargetId = null;
+            dragState.dropPosition = null;
+        }
+
+        function renderTree() {
+            elements.pageTree.innerHTML = '';
+            if (!state.pageTree.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'ページがありません。「新規ページ」を押して作成してください。';
+                elements.pageTree.appendChild(empty);
+                return;
+            }
+
+            const list = createTreeList(null);
+            state.pageTree.forEach(node => {
+                list.appendChild(createDropZoneItem(null, node.id, 'before'));
+                list.appendChild(renderTreeNode(node));
+            });
+            list.appendChild(createDropZoneItem(null, null, 'end'));
+            elements.pageTree.appendChild(list);
+        }
+
+        function renderTreeNode(node) {
+            const item = document.createElement('li');
+            const label = document.createElement('div');
+            label.className = 'tree-item';
+            if (node.id === state.currentPageId) {
+                label.classList.add('active');
+            }
+            label.textContent = node.title;
+            label.dataset.id = node.id;
+            label.draggable = true;
+            label.addEventListener('click', () => navigateToPage(node.id));
+            label.addEventListener('dragstart', handleDragStart);
+            label.addEventListener('dragend', handleDragEnd);
+            label.addEventListener('dragenter', handleItemDragEnter);
+            label.addEventListener('dragleave', handleItemDragLeave);
+            label.addEventListener('dragover', handleItemDragOver);
+            label.addEventListener('drop', handleItemDrop);
+            item.appendChild(label);
+
+            const childList = createTreeList(node.id);
+            node.children.forEach(child => {
+                childList.appendChild(createDropZoneItem(node.id, child.id, 'before'));
+                childList.appendChild(renderTreeNode(child));
+            });
+            childList.appendChild(createDropZoneItem(node.id, null, 'end'));
+            item.appendChild(childList);
+
+            return item;
+        }
+
+        function handleDropZoneDragOver(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            const zone = event.currentTarget;
+            const parentId = zone.dataset.parentId || '';
+            const referenceId = zone.dataset.referenceId || '';
+            const position = zone.dataset.position;
+            if (!position) {
+                return;
+            }
+            if (parentId && isDescendantId(parentId, dragState.sourceId)) {
+                return;
+            }
+            if (referenceId && (referenceId === dragState.sourceId || isDescendantId(referenceId, dragState.sourceId))) {
+                return;
+            }
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            zone.classList.add('active');
+            dragState.dropTargetId = referenceId || null;
+            dragState.dropPosition = position;
+        }
+
+        function handleDropZoneDragLeave(event) {
+            const zone = event.currentTarget;
+            zone.classList.remove('active');
+            const referenceId = zone.dataset.referenceId || null;
+            const position = zone.dataset.position || null;
+            if (dragState.dropTargetId === (referenceId || null) && dragState.dropPosition === position) {
+                dragState.dropTargetId = null;
+                dragState.dropPosition = null;
+            }
+        }
+
+        function handleDropZoneDrop(event) {
+            if (!dragState.sourceId) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const zone = event.currentTarget;
+            const parentId = zone.dataset.parentId || '';
+            const referenceId = zone.dataset.referenceId || '';
+            const position = zone.dataset.position;
+            zone.classList.remove('active');
+            if (!position) {
+                return;
+            }
+            if (parentId && isDescendantId(parentId, dragState.sourceId)) {
+                setStatus('子ページの下へは移動できません。', 'error');
+                dragState.dropTargetId = null;
+                dragState.dropPosition = null;
+                return;
+            }
+            if ((position === 'before' || position === 'after') && (!referenceId || referenceId === dragState.sourceId || isDescendantId(referenceId, dragState.sourceId))) {
+                dragState.dropTargetId = null;
+                dragState.dropPosition = null;
+                return;
+            }
+            if (position === 'before' || position === 'after') {
+                movePageRelative(dragState.sourceId, referenceId, position);
+            } else {
+                movePage(dragState.sourceId, parentId ? parentId : null);
+            }
+            dragState.dropTargetId = null;
+            dragState.dropPosition = null;
+        }
+
+        async function movePage(pageId, newParentId) {
+            if (!pageId) {
+                return;
+            }
+            const node = state.pageMap.get(pageId);
+            if (!node) {
+                return;
+            }
+            if (state.isNewPage && state.currentPageId === pageId) {
+                alert('新規ページは保存後に移動してください。');
+                return;
+            }
+            if (state.isDirty && state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                alert('未保存の変更があります。保存してから移動してください。');
+                return;
+            }
+
+            const parentId = newParentId || null;
+            const baseSlug = node.slug || getSlug(pageId);
+            const uniqueSlug = generateUniqueSlug(parentId, baseSlug, pageId);
+            const newId = parentId ? `${parentId}/${uniqueSlug}` : uniqueSlug;
+            const requiresRename = newId !== pageId;
+            let workingId = pageId;
+            let nextSelection = null;
+            try {
+                clearDropIndicators();
+                setStatus('ページを移動しています...');
+                beginLoading('ページを移動しています...');
+                if (requiresRename) {
+                    await dataService.renamePageTree({ originalId: pageId, newId });
+                    workingId = newId;
+                    if (state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                        const suffix = state.currentPageId.substring(pageId.length);
+                        nextSelection = newId + suffix;
+                    }
+                } else if (state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                    nextSelection = state.currentPageId;
+                }
+
+                await dataService.reorderPages({ movedId: workingId, targetId: null, position: 'end' });
+
+                const selectionTarget = nextSelection || state.currentPageId || workingId;
+                await loadPages(selectionTarget || undefined);
+                setStatus('ページを移動しました', 'success');
+            } catch (error) {
+                console.error('ページ移動エラー', error);
+                setStatus('ページの移動に失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        async function movePageRelative(pageId, referenceId, position) {
+            if (!pageId || !referenceId || !position) {
+                return;
+            }
+            const node = state.pageMap.get(pageId);
+            const targetNode = state.pageMap.get(referenceId);
+            if (!node || !targetNode) {
+                return;
+            }
+            if (state.isNewPage && state.currentPageId === pageId) {
+                alert('新規ページは保存後に移動してください。');
+                return;
+            }
+            if (state.isDirty && state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                alert('未保存の変更があります。保存してから移動してください。');
+                return;
+            }
+
+            const desiredParentId = targetNode.parentId || null;
+            const currentParentId = node.parentId || null;
+            const baseSlug = node.slug || getSlug(pageId);
+            let workingId = pageId;
+            let nextSelection = null;
+
+            try {
+                clearDropIndicators();
+                setStatus('ページを移動しています...');
+                beginLoading('ページを移動しています...');
+
+                if (desiredParentId !== currentParentId) {
+                    const uniqueSlug = generateUniqueSlug(desiredParentId, baseSlug, pageId);
+                    const newId = desiredParentId ? `${desiredParentId}/${uniqueSlug}` : uniqueSlug;
+                    if (newId !== pageId) {
+                        await dataService.renamePageTree({ originalId: pageId, newId });
+                        workingId = newId;
+                        if (state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                            const suffix = state.currentPageId.substring(pageId.length);
+                            nextSelection = newId + suffix;
+                        }
+                    } else {
+                        workingId = newId;
+                    }
+                }
+
+                await dataService.reorderPages({ movedId: workingId, targetId: referenceId, position });
+
+                if (!nextSelection && state.currentPageId && isDescendantId(state.currentPageId, pageId)) {
+                    const suffix = state.currentPageId.substring(pageId.length);
+                    nextSelection = workingId + suffix;
+                }
+
+                const selectionTarget = nextSelection || state.currentPageId || workingId;
+                await loadPages(selectionTarget || undefined);
+                setStatus('ページを移動しました', 'success');
+            } catch (error) {
+                console.error('ページ移動エラー', error);
+                setStatus('ページの移動に失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        function setStatus(message, type = 'info') {
+            elements.statusMessage.textContent = message || '';
+            elements.statusMessage.classList.remove('status-success', 'status-error');
+            if (type === 'success') {
+                elements.statusMessage.classList.add('status-success');
+            } else if (type === 'error') {
+                elements.statusMessage.classList.add('status-error');
+            }
+        }
+
+        function setUpdatedAt(text) {
+            elements.updatedAt.textContent = text || '';
+        }
+
+        async function loadPages(selectId) {
+            try {
+                setStatus('ページ一覧を読み込み中...');
+                beginLoading('ページ一覧を読み込み中...');
+                const pages = await dataService.getPages();
+                buildPageTree(pages);
+                renderTree();
+                setStatus('ページ一覧を更新しました', 'success');
+                if (selectId) {
+                    await navigateToPage(selectId);
+                } else if (!state.currentPageId && pages.length) {
+                    await navigateToPage(pages[0].id);
+                } else {
+                    renderTree();
+                }
+            } catch (error) {
+                console.error('ページ一覧の読み込みに失敗しました', error);
+                setStatus('ページ一覧の読み込みに失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        async function navigateToPage(id, { updateHistory: shouldUpdateHistory = true } = {}) {
+            if (!id) return;
+            if (state.isNewPage && state.currentPageId === id) {
+                renderTree();
+                return;
+            }
+            if (state.isDirty && !confirm('未保存の変更があります。ページを切り替えますか？')) {
+                return;
+            }
+            try {
+                setStatus('ページを読み込み中...');
+                beginLoading('ページを読み込み中...');
+                const page = await dataService.getPage(id);
+                state.currentPageId = page.id;
+                state.currentParentId = getParentId(page.id);
+                state.isNewPage = false;
+                state.isDirty = false;
+                if (state.pageMap.has(page.id)) {
+                    const node = state.pageMap.get(page.id);
+                    node.title = page.title || '無題';
+                    node.updatedAt = page.updatedAt || '';
+                }
+                const slug = getSlug(page.id);
+                elements.pageName.value = slug;
+                elements.pageName.disabled = false;
+                elements.pageTitle.value = page.title || '無題';
+                state.isApplyingContent = true;
+                state.editor.commands.setContent(page.content || '', false);
+                state.isApplyingContent = false;
+                hideLinkEditor();
+                renderToolbar();
+                setUpdatedAt(page.updatedAt ? `最終更新: ${new Date(page.updatedAt).toLocaleString('ja-JP')}` : '');
+                setStatus('ページを読み込みました', 'success');
+                updateBreadcrumb(page.id);
+                renderTree();
+                if (shouldUpdateHistory) {
+                    updateHistory(page.id);
+                }
+            } catch (error) {
+                console.error('ページ読み込みエラー', error);
+                setStatus('ページの読み込みに失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        function prepareToolbarUpdates() {
+            if (!state.editor) return;
+            state.editor.on('update', () => {
+                if (!state.isApplyingContent) {
+                    state.isDirty = true;
+                }
+                renderToolbar();
+                syncLinkEditorFromSelection();
+            });
+            state.editor.on('selectionUpdate', () => {
+                renderToolbar();
+                syncLinkEditorFromSelection();
+            });
+        }
+
+        async function saveCurrentPage() {
+            let slugInput = normalizeSlug(elements.pageName.value || '');
+            const titleInput = elements.pageTitle.value.trim();
+            if (!slugInput) {
+                alert('ページ名を入力してください。');
+                elements.pageName.focus();
+                return;
+            }
+
+            const parentId = state.currentParentId;
+            const id = parentId ? `${parentId}/${slugInput}` : slugInput;
+
+            if (isSlugTaken(parentId, slugInput, state.currentPageId)) {
+                alert('同じページ名のページが既に存在します。別の名前を指定してください。');
+                return;
+            }
+
+            const previousId = state.currentPageId;
+            const existingNode = previousId ? state.pageMap.get(previousId) : null;
+
+            const payload = {
+                id,
+                title: titleInput || slugInput,
+                content: state.editor.getHTML()
+            };
+
+            try {
+                setStatus('保存中です...');
+                beginLoading('保存しています...');
+                if (!state.isNewPage && previousId && id !== previousId) {
+                    elements.loadingMessage.textContent = 'ページIDを更新しています...';
+                    await dataService.renamePageTree({ originalId: previousId, newId: id });
+                    if (existingNode) {
+                        state.pageMap.delete(previousId);
+                        existingNode.id = id;
+                        existingNode.parentId = parentId || null;
+                        existingNode.slug = slugInput;
+                        state.pageMap.set(id, existingNode);
+                    }
+                    state.currentPageId = id;
+                    state.currentParentId = parentId || null;
+                    elements.loadingMessage.textContent = '保存しています...';
+                }
+                const orderNode = state.pageMap.get(id);
+                if (orderNode && Number.isFinite(orderNode.order)) {
+                    payload.order = orderNode.order;
+                }
+                const response = await dataService.savePage(payload);
+                if (response.updatedAt) {
+                    setUpdatedAt(`最終更新: ${new Date(response.updatedAt).toLocaleString('ja-JP')}`);
+                }
+                state.isDirty = false;
+                state.isNewPage = false;
+                state.currentPageId = id;
+                state.currentParentId = parentId || null;
+                slugInput = normalizeSlug(slugInput);
+                elements.pageName.value = slugInput;
+                elements.pageName.disabled = false;
+                await loadPages(id);
+                setStatus('保存しました', 'success');
+            } catch (error) {
+                console.error('保存エラー', error);
+                setStatus('保存に失敗しました: ' + error.message, 'error');
+            } finally {
+                endLoading();
+            }
+        }
+
+        function createNewPage(parentId = null) {
+            const defaultName = parentId ? `${getSlug(parentId)}-child` : 'new-page';
+            const pageName = normalizeSlug(prompt('ページ名（内部識別子）を入力してください', defaultName) || '');
+            if (!pageName) {
+                return;
+            }
+            if (state.isNewPage && state.currentPageId) {
+                removeNode(state.currentPageId);
+            }
+            const pageTitle = prompt('ページタイトル（表示名）を入力してください', pageName) || pageName;
+            const id = parentId ? `${parentId}/${pageName}` : pageName;
+            if (isSlugTaken(parentId, pageName, state.currentPageId)) {
+                alert('同じページ名のページが既に存在します。別の名前を指定してください。');
+                return;
+            }
+
+            state.currentParentId = parentId;
+            state.currentPageId = id;
+            state.isNewPage = true;
+            state.isDirty = true;
+            elements.pageName.disabled = false;
+            elements.pageName.value = pageName;
+            elements.pageTitle.value = pageTitle;
+            state.isApplyingContent = true;
+            state.editor.commands.setContent('', false);
+            state.isApplyingContent = false;
+            hideLinkEditor();
+            renderToolbar();
+            const node = {
+                id,
+                title: pageTitle || '無題',
+                updatedAt: '',
+                parentId,
+                slug: pageName,
+                children: []
+            };
+            insertNode(node);
+            updateBreadcrumb(id);
+            setUpdatedAt('');
+            setStatus('新しいページを作成しました。保存して反映してください。');
+            renderTree();
+            updateHistory(id);
+        }
+
+        function attachEventListeners() {
+            elements.savePage.addEventListener('click', saveCurrentPage);
+            elements.createRootPage.addEventListener('click', () => createNewPage(null));
+            elements.addChildPage.addEventListener('click', () => {
+                if (!state.currentPageId) {
+                    alert('子ページを作成する親ページを選択してください。');
+                    return;
+                }
+                createNewPage(state.currentPageId);
+            });
+            elements.reloadPages.addEventListener('click', () => loadPages(state.currentPageId));
+            elements.pageTitle.addEventListener('input', () => {
+                state.isDirty = true;
+                if (state.isNewPage && state.currentPageId && state.pageMap.has(state.currentPageId)) {
+                    const node = state.pageMap.get(state.currentPageId);
+                    node.title = elements.pageTitle.value.trim() || node.slug || '無題';
+                    renderTree();
+                }
+            });
+            elements.pageName.addEventListener('input', () => {
+                const slug = normalizeSlug(elements.pageName.value || '');
+                if (elements.pageName.value !== slug) {
+                    elements.pageName.value = slug;
+                    if (document.activeElement === elements.pageName) {
+                        const position = slug.length;
+                        elements.pageName.setSelectionRange(position, position);
+                    }
+                }
+                state.isDirty = true;
+                if (state.isNewPage) {
+                    updateProvisionalPageId(slug);
+                }
+                const prospectiveId = slug
+                    ? (state.currentParentId ? `${state.currentParentId}/${slug}` : slug)
+                    : state.currentPageId;
+                updateBreadcrumb(prospectiveId);
+            });
+            elements.viewPage.addEventListener('click', () => {
+                let targetId = state.currentPageId;
+                if (state.isNewPage) {
+                    const slug = normalizeSlug(elements.pageName.value || '');
+                    if (!slug) {
+                        alert('ページ名を入力してください。');
+                        elements.pageName.focus();
+                        return;
+                    }
+                    targetId = state.currentParentId ? `${state.currentParentId}/${slug}` : slug;
+                }
+                if (!targetId) {
+                    alert('ページを選択してください。');
+                    return;
+                }
+                const viewUrl = `./view.html?page=${encodeURIComponent(targetId)}`;
+                window.open(viewUrl, '_blank', 'noopener,noreferrer');
+            });
+            elements.linkTargetToggle.addEventListener('click', () => {
+                state.linkEditor.openInNewTab = !state.linkEditor.openInNewTab;
+                updateLinkTargetToggle();
+            });
+            elements.linkApply.addEventListener('click', applyLinkFromEditor);
+            elements.linkRemove.addEventListener('click', removeLinkFromSelection);
+            elements.linkCancel.addEventListener('click', () => {
+                hideLinkEditor();
+                state.editor?.commands.focus();
+            });
+            elements.youtubePasteAsUrl?.addEventListener('click', applyYouTubePasteAsUrl);
+            elements.youtubeEmbedVideo?.addEventListener('click', applyYouTubeEmbed);
+            elements.linkInput.addEventListener('keydown', event => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    applyLinkFromEditor();
+                } else if (event.key === 'Escape') {
+                    event.preventDefault();
+                    hideLinkEditor();
+                    state.editor?.commands.focus();
+                }
+            });
+            elements.editorWrapper?.addEventListener('scroll', () => {
+                updateToolbarShadow();
+                if (state.youtubePaste.visible) {
+                    hideYouTubePastePopup();
+                }
+            });
+            elements.editor?.addEventListener('click', preventEditorLinkNavigation);
+            elements.editor?.addEventListener('auxclick', preventEditorLinkNavigation);
+            elements.editor?.addEventListener('paste', handleEditorPaste);
+            window.addEventListener('resize', () => {
+                requestAnimationFrame(updateToolbarMetrics);
+                if (state.youtubePaste.visible) {
+                    hideYouTubePastePopup();
+                }
+            });
+            window.addEventListener('beforeunload', event => {
+                if (state.isDirty) {
+                    event.preventDefault();
+                    event.returnValue = '';
+                }
+            });
+            document.addEventListener('keydown', event => {
+                if (event.key === 'Escape' && state.youtubePaste.visible) {
+                    event.preventDefault();
+                    hideYouTubePastePopup();
+                    state.editor?.commands.focus();
+                }
+            });
+            document.addEventListener('mousedown', event => {
+                if (!state.youtubePaste.visible || !elements.youtubePastePopup) {
+                    return;
+                }
+                if (elements.youtubePastePopup.contains(event.target)) {
+                    return;
+                }
+                hideYouTubePastePopup();
+            });
+        }
+
+        function initEditor() {
+            state.editor = new Editor({
+                element: elements.editor,
+                extensions: [
+                    StarterKit.configure({
+                        heading: {
+                            levels: [1, 2, 3]
+                        }
+                    }),
+                    Placeholder.configure({
+                        placeholder: 'ここにコンテンツを入力してください...'
+                    }),
+                    Link.configure({
+                        openOnClick: false,
+                        autolink: true,
+                        linkOnPaste: true
+                    }),
+                    Table.configure({ resizable: true }),
+                    TableRow,
+                    TableHeader,
+                    TableCell,
+                    ResizableImage.configure({
+                        inline: false,
+                        allowBase64: false,
+                        HTMLAttributes: {
+                            class: 'editor-image',
+                            loading: 'lazy'
+                        },
+                        resizeConstraints: {
+                            minShortSide: 20,
+                            maxLongSide: 860
+                        }
+                    }),
+                    DriveImageExtension.configure({
+                        webAppUrl: DRIVE_IMAGE_APPS_SCRIPT_ENDPOINT,
+                        maxFileSize: 10 * 1024 * 1024,
+                        allowedMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
+                        uploadTimeout: 45000,
+                        maxConcurrentUploads: 2,
+                        galleryTimeout: 20000,
+                        galleryCacheTimeout: 0,
+                        enablePasteUpload: true,
+                        enableDropUpload: true,
+                        addToToolbar: false,
+                        toolbarSelector: '.toolbar',
+                        buttonClass: 'btn',
+                        debug: false
+                    }),
+                    UITemplateExtension.configure({
+                        getManager: () => state.templateManager
+                    }),
+                    YouTubeEmbed
+                ],
+                content: '',
+                onUpdate() {
+                    if (!state.isApplyingContent) {
+                        state.isDirty = true;
+                    }
+                }
+            });
+            state.templateManager = new TemplateManager({
+                getEditor: () => state.editor,
+                modal: elements.templateModal,
+                listView: elements.templateListView,
+                listContainer: elements.templateItems,
+                openCreatorButton: elements.templateCreateButton,
+                creatorView: elements.templateCreatorView,
+                templateForm: elements.templateForm,
+                templateNameInput: elements.templateNameInput,
+                elementList: elements.templateElementList,
+                addElementButton: elements.templateAddElement,
+                cancelCreateButton: elements.templateCancel,
+                closeButton: elements.templateModalClose,
+                backdrop: elements.templateModalBackdrop,
+                previewContainer: elements.templatePreview
+            });
+            renderToolbar();
+            prepareToolbarUpdates();
+            refreshToolbarAffordances();
+        }
+
+        function initialize() {
+            initEditor();
+            attachEventListeners();
+            const initialPageId = getPageIdFromQuery();
+            if (initialPageId) {
+                updateHistory(initialPageId);
+            }
+            loadPages(initialPageId || undefined);
+        }
+
+        initialize();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a live preview panel and layout controls to the template creator workflow
- generate template markup with text/image placeholders and DriveImage click handling
- wire the TipTap page to pass the preview container into the template manager

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4b6628f04832bb540152d4d86dff1