### PR TITLE
TipTapツールバーの主要ボタンをSVGアイコン化

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -679,6 +679,20 @@
             border-color: #2383e2;
         }
 
+        .toolbar button svg {
+            width: 18px;
+            height: 18px;
+            display: block;
+        }
+
+        .toolbar button svg [fill="#000000"] {
+            fill: currentColor;
+        }
+
+        .toolbar button svg [stroke="#000000"] {
+            stroke: currentColor;
+        }
+
         .page-link-panel {
             position: absolute;
             top: 16px;
@@ -3266,11 +3280,26 @@
         const APPS_SCRIPT_ENDPOINT_TOOLBAR_PLUGIN = window.APPS_SCRIPT_ENDPOINT_TOOLBAR_PLUGIN;
         const APPS_SCRIPT_ENDPOINT_DRIVE_IMAGE_PERMISSION = APPS_SCRIPT_ENDPOINT_TOOLBAR_PLUGIN;
 
+        const TOOLBAR_ICONS = {
+            bold: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 26 26"><path fill="#000000" d="M22.941 18.046c0 1.116-.234 2.06-.706 2.828c-.47.772-1.144 1.378-2.022 1.825c-.932.473-2.003.811-3.217 1.008c-1.215.195-1.644.293-3.288.293H2v-1.784c.32-.028 2.031-.421 2.031-1.953V6.053C4.031 4.197 2.32 3.979 2 3.929V2h11.953c3.008 0 3.639.414 4.973 1.239c1.334.829 2 2.048 2 3.66c0 3.087-2.469 4.929-3.275 5.116v.294c.806.083 5.29.951 5.29 5.737zM15.434 7.824c0-.911-.344-1.623-1.031-2.132c-.687-.515-1.488-.769-2.862-.769c-.196 0-.452.007-.766.018c-.316.012-.588.022-.815.029v6.102h.806c1.675 0 2.68-.293 3.476-.877c.793-.583 1.192-1.372 1.192-2.371zm.814 9.651c0-1.165-.435-2.061-1.309-2.682c-.871-.623-1.903-.934-3.539-.934c-.188 0-.438.006-.75.018l-.691.029v7.174h2.307c1.18 0 2.137-.314 2.876-.945c.737-.63 1.106-1.518 1.106-2.66z"/></svg>`,
+            link: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24"><path fill="#000000" d="m12.922 16.587l-3.671 3.671a3.896 3.896 0 0 1-5.504-5.509l-.002.002l3.671-3.671a1.3 1.3 0 0 0-1.837-1.835l.001-.001l-3.671 3.671a6.494 6.494 0 0 0 9.187 9.175l-.003.002l3.671-3.671a1.3 1.3 0 0 0-1.837-1.835l.001-.001zM24.007 6.489A6.494 6.494 0 0 0 12.921 1.9L9.25 5.571a1.3 1.3 0 1 0 1.835 1.837l.001-.001l3.671-3.671a3.896 3.896 0 0 1 5.504 5.509l.002-.002l-3.671 3.671a1.3 1.3 0 1 0 1.835 1.837l.001-.001l3.671-3.671a6.432 6.432 0 0 0 1.908-4.58V6.49z"/><path fill="#000000" d="M7.412 16.592c.235.235.559.38.918.38s.683-.145.918-.38L16.59 9.25a1.3 1.3 0 0 0-1.837-1.835l.001-.001l-7.342 7.342c-.235.235-.38.559-.38.918s.145.683.38.918z"/></svg>`,
+            pageLink: `<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><g fill="none"><path d="M5.5 3A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V8.828a2.5 2.5 0 0 0-.732-1.767l-3.329-3.329A2.5 2.5 0 0 0 11.172 3H5.5zM4 5.5A1.5 1.5 0 0 1 5.5 4H11v3.5A1.5 1.5 0 0 0 12.5 9H16v5.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 4 14.5v-9zM15.75 8H12.5a.5.5 0 0 1-.5-.5V4.25c.083.054.16.118.232.19l3.329 3.328c.071.071.134.149.19.232z" fill="#000000"/></g></svg>`,
+            heading1: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24"><path fill="none" stroke="#000000" stroke-linecap="round" stroke-width="2" d="M6 7v5m0 5v-5m0 0h6m0-5v5m0 5v-5m7 5v-6.786a.1.1 0 0 0-.164-.077L16 12.5"/></svg>`,
+            heading2: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24"><path fill="none" stroke="#000000" stroke-linecap="round" stroke-width="2" d="M6 7v5m0 5v-5m0 0h6m0-5v5m0 5v-5m7 5v-6.786a.1.1 0 0 0-.164-.077L16 12.5"/></svg>`,
+            heading3: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24"><path fill="none" stroke="#000000" stroke-linecap="round" stroke-width="2" d="M6 7v5m0 5v-5m0 0h6m0-5v5m0 5v-5m4-1c0-.5.832-1 1.6-1s1.9.311 1.9 1.5a1.535 1.535 0 0 1-.952 1.482c-.01.004-.008.023.002.024c.261.04 1.45.3 1.45 1.794c0 1.2-.5 2.2-2.2 2.2c0 0-1.8 0-1.8-.7"/></svg>`,
+            bulletList: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 32 32"><path fill="none" stroke="#000000" stroke-linecap="round" stroke-width="2" d="M12 8h15m-15 8h9m-9 8h15M7 24a1 1 0 1 1-2 0a1 1 0 0 1 2 0Zm0-8a1 1 0 1 1-2 0a1 1 0 0 1 2 0Zm0-8a1 1 0 1 1-2 0a1 1 0 0 1 2 0Z"/></svg>`,
+            orderedList: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 20 20"><path fill="#000000" d="M5 1.5a.5.5 0 0 0-.385-.487a.507.507 0 0 0-.564.266a3.505 3.505 0 0 1-.317.471a2.957 2.957 0 0 1-.958.803a.5.5 0 1 0 .448.894c.3-.15.558-.336.776-.529V5.5a.5.5 0 0 0 1 0v-4ZM8.75 4a.75.75 0 1 0 0 1.5h7.5a.75.75 0 0 0 0-1.5h-7.5Zm0 5a.75.75 0 1 0 0 1.5h7.5a.75.75 0 0 0 0-1.5h-7.5ZM8 14.75a.75.75 0 0 1 .75-.75h7.5a.75.75 0 0 1 0 1.5h-7.5a.75.75 0 0 1-.75-.75ZM2.646 7.646a.5.5 0 0 0 .704.71l.007-.005a1.436 1.436 0 0 1 .237-.163c.17-.095.416-.188.718-.188c.227.004.41.065.524.149c.096.07.163.17.163.351c0 .202-.07.32-.21.436c-.152.126-.349.224-.619.357l-.145.072c-.313.157-.702.364-1.005.697c-.322.354-.521.819-.521 1.438a.5.5 0 0 0 .5.5h2.5a.5.5 0 0 0 0-1H3.59a.93.93 0 0 1 .17-.265c.166-.183.402-.32.714-.475c.038-.02.079-.04.121-.06c.262-.129.584-.286.834-.496C5.758 9.431 6 9.048 6 8.5c0-.504-.223-.9-.568-1.155C5.106 7.103 4.7 7.006 4.326 7h-.009a2.498 2.498 0 0 0-1.655.632l-.01.008l-.003.004l-.001.001l-.002.001Zm.016-.014l-.016.014s.101-.09.016-.014ZM3.75 15.5a.5.5 0 0 1 .5-.5c.343 0 .532-.097.628-.183a.374.374 0 0 0 .129-.298c-.008-.194-.186-.52-.757-.52c-.412 0-.626.103-.723.167a.417.417 0 0 0-.088.076l-.004.005a.5.5 0 0 1-.882-.47v-.002l.001-.002l.002-.003l.003-.006l.01-.016a1.077 1.077 0 0 1 .103-.146c.066-.081.164-.177.3-.268c.28-.186.69-.334 1.278-.334c1.03 0 1.726.675 1.756 1.481c.014.368-.118.736-.396 1.019c.278.283.41.651.396 1.019c-.03.806-.727 1.48-1.756 1.48c-.587 0-.999-.147-1.277-.333a1.407 1.407 0 0 1-.302-.268a1.065 1.065 0 0 1-.103-.146l-.009-.016l-.003-.006l-.002-.004v-.001l-.001-.002a.5.5 0 0 1 .882-.47l.004.005c.01.013.038.042.088.076c.097.064.31.166.723.166c.57 0 .75-.325.757-.519a.374.374 0 0 0-.13-.298C4.783 16.097 4.594 16 4.25 16a.5.5 0 0 1-.5-.5Zm-.315-1.253a.511.511 0 0 0 .012-.023l-.001.002l-.001.003l-.003.004l-.004.008l-.005.008l.002-.002Z"/></svg>`,
+            blockquote: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 16 16"><path fill="#000000" fill-rule="evenodd" d="M1.5 3.75a.75.75 0 0 0-1.5 0v8.5a.75.75 0 0 0 1.5 0v-8.5ZM4.75 3a.75.75 0 0 0 0 1.5h7.5a.75.75 0 0 0 0-1.5h-7.5Zm0 4.25a.75.75 0 0 0 0 1.5h10.5a.75.75 0 0 0 0-1.5H4.75Zm-.75 5a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/></svg>`,
+            table: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 14 14" fill="#000000"><g fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round"><path d="M4.983 5.5v7.656M.838 9h12.323M.96 10.269a3.13 3.13 0 0 0 2.753 2.76c1.07.119 2.167.221 3.287.221s2.218-.102 3.287-.222a3.13 3.13 0 0 0 2.753-2.76c.114-1.063.21-2.155.21-3.268s-.096-2.205-.21-3.269a3.13 3.13 0 0 0-2.753-2.76C9.217.853 8.12.75 7 .75S4.782.852 3.713.972A3.13 3.13 0 0 0 .96 3.732C.846 4.794.75 5.886.75 7s.096 2.205.21 3.269"/><path d="M.802 5.5h12.396a43 43 0 0 0-.158-1.769a3.13 3.13 0 0 0-2.753-2.76C9.217.853 8.12.75 7 .75S4.782.852 3.712.972A3.13 3.13 0 0 0 .96 3.732C.897 4.311.84 4.901.802 5.5"/></g></svg>`,
+            heroSkillsetCard: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24"><path fill="#000000" d="M17.5 12a5.5 5.5 0 1 1 0 11a5.5 5.5 0 0 1 0-11Zm0 2l-.09.007a.5.5 0 0 0-.402.402L17 14.5V17h-2.502l-.09.008a.5.5 0 0 0-.402.402l-.008.09l.008.09a.5.5 0 0 0 .402.402l.09.008H17v2.503l.008.09a.5.5 0 0 0 .402.402l.09.008l.09-.008a.5.5 0 0 0 .402-.402l.008-.09V18l2.504.001l.09-.008a.5.5 0 0 0 .402-.402l.008-.09l-.008-.09a.5.5 0 0 0-.403-.402l-.09-.008H18v-2.5l-.008-.09a.5.5 0 0 0-.402-.403L17.5 14Zm-3.246-4a2.25 2.25 0 0 1 1.951 1.13a6.44 6.44 0 0 0-1.518.509a.736.736 0 0 0-.433-.139H9.752a.75.75 0 0 0-.75.75v4.249c0 1.41.974 2.594 2.286 2.915a6.42 6.42 0 0 0 .735 1.587l-.02-.001a4.501 4.501 0 0 1-4.501-4.501V12.25A2.25 2.25 0 0 1 9.752 10h4.502Zm-6.848 0a3.243 3.243 0 0 0-.817 1.5H4.25a.75.75 0 0 0-.75.75v2.749a2.501 2.501 0 0 0 3.082 2.433c.085.504.24.985.453 1.432A4.001 4.001 0 0 1 2 14.999V12.25a2.25 2.25 0 0 1 2.096-2.245L4.25 10h3.156Zm12.344 0A2.25 2.25 0 0 1 22 12.25v.56A6.478 6.478 0 0 0 17.5 11l-.245.005A3.21 3.21 0 0 0 16.6 10h3.15ZM18.5 4a2.5 2.5 0 1 1 0 5a2.5 2.5 0 0 1 0-5ZM12 3a3 3 0 1 1 0 6a3 3 0 0 1 0-6ZM5.5 4a2.5 2.5 0 1 1 0 5a2.5 2.5 0 0 1 0-5Zm13 1.5a1 1 0 1 0 0 2a1 1 0 0 0 0-2Zm-6.5-1a1.5 1.5 0 1 0 0 3a1.5 1.5 0 0 0 0-3Zm-6.5 1a1 1 0 1 0 0 2a1 1 0 0 0 0-2Z"/></svg>`,
+            driveImage: `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24"><path fill="#000000" d="M19 4H5a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3ZM5 18a1 1 0 0 1-1-1v-2.42l3.3-3.29a1 1 0 0 1 1.4 0L15.41 18Zm15-1a1 1 0 0 1-1 1h-.77l-3.81-3.83l.88-.88a1 1 0 0 1 1.4 0l3.3 3.29Zm0-3.24l-1.88-1.87a3.06 3.06 0 0 0-4.24 0l-.88.88l-2.88-2.88a3.06 3.06 0 0 0-4.24 0L4 11.76V7a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1Z"/></svg>`
+        };
+
         const TOOLBAR_FEATURES = [
             {
                 key: 'bold',
                 label: '太字',
-                createButton: editor => createToolbarButton('B', () => editor.chain().focus().toggleBold().run(), () => editor.isActive('bold'), '太字')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.bold, () => editor.chain().focus().toggleBold().run(), () => editor.isActive('bold'), '太字')
             },
             {
                 key: 'italic',
@@ -3280,42 +3309,42 @@
             {
                 key: 'link',
                 label: 'リンクを挿入/編集',
-                createButton: editor => createToolbarButton('🔗', handleLinkButtonClick, () => isLinkActive(editor), 'リンクを挿入/編集')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.link, handleLinkButtonClick, () => isLinkActive(editor), 'リンクを挿入/編集')
             },
             {
                 key: 'pageLink',
                 label: 'ページリンクカードを挿入',
-                createButton: editor => createToolbarButton('🔖', handlePageLinkButtonClick, () => state.pageLink.visible || editor.isActive('pageLinkCard'), 'ページリンクカードを挿入')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.pageLink, handlePageLinkButtonClick, () => state.pageLink.visible || editor.isActive('pageLinkCard'), 'ページリンクカードを挿入')
             },
             {
                 key: 'heading1',
                 label: '見出し 1',
-                createButton: editor => createToolbarButton('H1', () => editor.chain().focus().toggleHeading({ level: 1 }).run(), () => editor.isActive('heading', { level: 1 }), '見出し 1')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.heading1, () => editor.chain().focus().toggleHeading({ level: 1 }).run(), () => editor.isActive('heading', { level: 1 }), '見出し 1')
             },
             {
                 key: 'heading2',
                 label: '見出し 2',
-                createButton: editor => createToolbarButton('H2', () => editor.chain().focus().toggleHeading({ level: 2 }).run(), () => editor.isActive('heading', { level: 2 }), '見出し 2')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.heading2, () => editor.chain().focus().toggleHeading({ level: 2 }).run(), () => editor.isActive('heading', { level: 2 }), '見出し 2')
             },
             {
                 key: 'heading3',
                 label: '見出し 3',
-                createButton: editor => createToolbarButton('H3', () => editor.chain().focus().toggleHeading({ level: 3 }).run(), () => editor.isActive('heading', { level: 3 }), '見出し 3')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.heading3, () => editor.chain().focus().toggleHeading({ level: 3 }).run(), () => editor.isActive('heading', { level: 3 }), '見出し 3')
             },
             {
                 key: 'bulletList',
                 label: '箇条書きリスト',
-                createButton: editor => createToolbarButton('UL', () => editor.chain().focus().toggleBulletList().run(), () => editor.isActive('bulletList'), '箇条書きリスト')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.bulletList, () => editor.chain().focus().toggleBulletList().run(), () => editor.isActive('bulletList'), '箇条書きリスト')
             },
             {
                 key: 'orderedList',
                 label: '番号付きリスト',
-                createButton: editor => createToolbarButton('OL', () => editor.chain().focus().toggleOrderedList().run(), () => editor.isActive('orderedList'), '番号付きリスト')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.orderedList, () => editor.chain().focus().toggleOrderedList().run(), () => editor.isActive('orderedList'), '番号付きリスト')
             },
             {
                 key: 'blockquote',
                 label: '引用',
-                createButton: editor => createToolbarButton('""', () => editor.chain().focus().toggleBlockquote().run(), () => editor.isActive('blockquote'), '引用')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.blockquote, () => editor.chain().focus().toggleBlockquote().run(), () => editor.isActive('blockquote'), '引用')
             },
             {
                 key: 'codeBlock',
@@ -3325,17 +3354,17 @@
             {
                 key: 'table',
                 label: '表を挿入',
-                createButton: editor => createToolbarButton('表', () => editor.chain().focus().insertTable({ rows: 3, cols: 3 }).run(), () => false, '表を挿入')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.table, () => editor.chain().focus().insertTable({ rows: 3, cols: 3 }).run(), () => false, '表を挿入')
             },
             {
                 key: 'heroSkillsetCard',
                 label: '英雄スキル構成カード',
-                createButton: editor => createToolbarButton('🛡️', () => editor.chain().focus().insertHeroSkillsetCard().run(), () => editor.isActive('heroSkillsetCard'), '英雄スキル構成カードを挿入')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.heroSkillsetCard, () => editor.chain().focus().insertHeroSkillsetCard().run(), () => editor.isActive('heroSkillsetCard'), '英雄スキル構成カードを挿入')
             },
             {
                 key: 'driveImage',
                 label: 'Drive画像を挿入',
-                createButton: editor => createToolbarButton('🖼️', () => editor.commands.openImageModal(), () => false, 'Drive画像を挿入')
+                createButton: editor => createToolbarButton(TOOLBAR_ICONS.driveImage, () => editor.commands.openImageModal(), () => false, 'Drive画像を挿入')
             }
         ];
 
@@ -3986,10 +4015,11 @@
             return !!imageAttrs?.href;
         }
 
-        function createToolbarButton(label, command, isActive, tooltip) {
+        function createToolbarButton(iconSvg, command, isActive, tooltip) {
             const button = document.createElement('button');
             button.type = 'button';
-            button.textContent = label;
+            button.innerHTML = iconSvg;
+            button.setAttribute('aria-label', tooltip || 'ツールバー操作');
             button.addEventListener('click', command);
             if (tooltip) {
                 button.title = tooltip;


### PR DESCRIPTION
### Motivation
- TipTap エディタのツールバーで一貫したアイコン表示にするため、指定のSVGをボタン表示に使いテキスト/絵文字フォールバックを廃止しました。\n
### Description
- `edit.html` に `TOOLBAR_ICONS` 定数を追加し、要求された各ボタン（bold / link / page card / H1 / H2 / H3 / UL / OL / quote / table / hero skill card / image）のSVGを登録しました。\n
- `TOOLBAR_FEATURES` の該当 `createButton` 呼び出しをテキスト/絵文字から `TOOLBAR_ICONS` のSVG参照へ置換しました（他の機能は従来のまま）。\n
- `createToolbarButton` を `textContent` ベースから `innerHTML` ベースに変更し、SVGを直接挿入する実装に変更しつつ `aria-label` を設定してアクセシビリティを維持しました。\n
- ツールバー内SVGのサイズ指定と、SVG内の `fill="#000000"` / `stroke="#000000"` を `currentColor` に追従させるCSSを追加し、アクティブ状態でも色が適切に反映されるようにしました。\n
### Testing
- 自動差分チェックとして `git diff --check` を実行し問題なし（成功）。\n
- 開発サーバーを `python -m http.server 4173` で起動して `edit.html` を表示し、Playwright スクリプトでページを開いてスクリーンショットを取得して表示確認を行いました（成功）。\n
- 変更は `edit.html` のみで実装され、上記自動手順はすべて成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2ec64c8c832b99571c0895a6ac2c)